### PR TITLE
feat(ios): use @objc for bridge and auxiliary APIs

### DIFF
--- a/IonicPortals/IonicPortals/PortalBuilder.swift
+++ b/IonicPortals/IonicPortals/PortalBuilder.swift
@@ -53,7 +53,7 @@ public class PortalBuilder: NSObject {
      * - Parameter liveUpdateConfig: A live update object that contains information on how to handle the Appflow Live Update functionality
      * - Parameter updateOnAppLoad: Starts an immediate sync to download the latest update on the Portal
      */
-    public func setLiveUpdateConfig(liveUpdateConfig: LiveUpdate, updateOnAppLoad: Bool = true) -> PortalBuilder {
+    @objc public func setLiveUpdateConfig(liveUpdateConfig: LiveUpdate, updateOnAppLoad: Bool = true) -> PortalBuilder {
         self.liveUpdateConfig = liveUpdateConfig
         LiveUpdateManager.initialize()
         LiveUpdateManager.cleanVersions(liveUpdateConfig.appId)

--- a/IonicPortals/IonicPortals/PortalWebView.swift
+++ b/IonicPortals/IonicPortals/PortalWebView.swift
@@ -10,7 +10,7 @@ public class PortalWebView: UIView {
     lazy var webView = InternalCapWebView(portal: portal, liveUpdatePath: liveUpdatePath)
     var portal: Portal
     var liveUpdatePath: URL? = nil
-    public var bridge: CAPBridgeProtocol {
+    @objc public var bridge: CAPBridgeProtocol {
         webView.bridge
     }
     
@@ -40,7 +40,7 @@ public class PortalWebView: UIView {
         }
     }
     
-    func reload() {
+    @objc public func reload() {
         guard let liveUpdate = portal.liveUpdateConfig else { return }
         guard let capViewController = bridge.viewController as? CAPBridgeViewController else { return }
         guard let latestAppPath = LiveUpdateManager.getLatestAppDirectory(liveUpdate.appId) else { return }


### PR DESCRIPTION
This allows Capacitor plugins to be registered with the bridge, for example:
https://github.com/NativeScript/plugins/commit/644b896d8b5e3c5b8f89377e25b2797c2d50eb25#diff-8ccbf3f8847b6a1b15944609e0e0610409a8b5e910076d7298aeab62cd998e84R46