### PR TITLE
feat: Make PortalBuilder factory methods annotated with @discardableResult

### DIFF
--- a/IonicPortals/IonicPortals/PortalBuilder.swift
+++ b/IonicPortals/IonicPortals/PortalBuilder.swift
@@ -32,6 +32,7 @@ public class PortalBuilder: NSObject {
      * - Parameter startDir: The relative file path of the folder that contains your web app
      * - Returns: self
      */
+    @discardableResult
     @objc public func setStartDir(_ startDir: String) -> PortalBuilder {
         self.startDir = startDir
         return self
@@ -43,6 +44,7 @@ public class PortalBuilder: NSObject {
      * - Parameter initialContext: An object that can be serialized into JSON
      * - Returns: self
      */
+    @discardableResult
     @objc public func setInitialContext(_ initialContext: Dictionary<String, Any>) -> PortalBuilder {
         self.initialContext = initialContext
         return self
@@ -53,6 +55,7 @@ public class PortalBuilder: NSObject {
      * - Parameter liveUpdateConfig: A live update object that contains information on how to handle the Appflow Live Update functionality
      * - Parameter updateOnAppLoad: Starts an immediate sync to download the latest update on the Portal
      */
+    @discardableResult
     @objc public func setLiveUpdateConfig(liveUpdateConfig: LiveUpdate, updateOnAppLoad: Bool = true) -> PortalBuilder {
         self.liveUpdateConfig = liveUpdateConfig
         LiveUpdateManager.initialize()


### PR DESCRIPTION
I noticed when using IonicPortals from Objective-C that using PortalBuilder was a bit cluttered chaining the methods/messages like this:
```objective-c
Portal *portal = [[[[[PortalBuilder alloc] initWithName:@"hello"] setStartDir:@"portals/hello"] setInitialContext:@{ @"greeting": @"Hello, world!"}] create];
```

When I broke it up to make it more readable, I noticed I got compiler warnings for ignoring unused results:
```objective-c
PortalBuilder *builder = [[PortalBuilder alloc] initWithName:@"hello"];
[builder setStartDir:@"portals/hello"]; // compiler warning here
[builder setInitialContext:@{ @"greeting": @"Hello, world!" }]; // compiler warning here
Portal *portal = [builder create];
[PortalManager addPortal: portal]
```