### PR TITLE
fix: Swift Concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ on:
       - '**'
 jobs:
   verify-ios:
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 30
     steps:
-      - run: sudo xcode-select --switch /Applications/Xcode_13.2.app
+      - run: sudo xcode-select --switch /Applications/Xcode_13.3.1.app
       - uses: actions/checkout@v2
       - name: Install Cocoapods
         run: gem install cocoapods xcpretty

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ on:
       - '**'
 jobs:
   verify-ios:
-    runs-on: macos-12
+    runs-on: macos-latest
     timeout-minutes: 30
     steps:
-      - run: sudo xcode-select --switch /Applications/Xcode_13.3.1.app
+      - run: sudo xcode-select --switch /Applications/Xcode_13.2.1.app
       - uses: actions/checkout@v2
       - name: Install Cocoapods
         run: gem install cocoapods xcpretty

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         run: gem install cocoapods xcpretty
       - run: pod install
       - run: |
+          set -eo pipefail
           xcodebuild test \
           -workspace IonicPortals.xcworkspace \
           -scheme IonicPortals \

--- a/IonicPortals/IonicPortals/PortalsPlugin+SwiftConcurrency.swift
+++ b/IonicPortals/IonicPortals/PortalsPlugin+SwiftConcurrency.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.6) && canImport(_Concurrency)
 extension PortalsPlugin {
     /// Subscribe to a topic and receive the events in an `AsyncStream`
     /// - Parameter topic: The topic to subscribe to

--- a/IonicPortals/IonicPortalsTests/PortalsPluginTests.swift
+++ b/IonicPortals/IonicPortalsTests/PortalsPluginTests.swift
@@ -207,6 +207,7 @@ class PortalsPluginTests: XCTestCase {
         XCTAssertTrue(completed)
     }
     
+    #if compiler(>=5.6)
     func test_asyncSubscribe__when_values_are_published__they_are_able_to_be_manipulated_with_async_sequence_apis() async {
         let sut = Task {
             await PortalsPlugin.subscribe("test:asyncstream")
@@ -232,4 +233,5 @@ class PortalsPluginTests: XCTestCase {
         
         XCTAssertEqual(firstValue, 1)
     }
+    #endif
 }


### PR DESCRIPTION
Bumps the required version of Swift to 5.6 for the concurrency features. There was an issue with Concurrency backporting that had some nasty issues (runtime crashes, bad bitcode stripping etc). The rationale behind requiring Swift 5.6 is that is currently what ships with Xcode 13.3.1 (the version of Xcode containing the fixes). This does also ship in 13.3.0, however the total possible surface area of affected customers is only for the single point release.