### PR TITLE
Clean(er) Objective-C API

### DIFF
--- a/IonicPortals/IonicPortals.xcodeproj/project.pbxproj
+++ b/IonicPortals/IonicPortals.xcodeproj/project.pbxproj
@@ -18,7 +18,7 @@
 		A725DEE627D0266100109471 /* PortalsPlugin+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A725DEE527D0266100109471 /* PortalsPlugin+Combine.swift */; };
 		A725DEEA27D1548C00109471 /* JSONEncoder+JSObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = A725DEE927D1548C00109471 /* JSONEncoder+JSObject.swift */; };
 		A725DEEC27D1553D00109471 /* JSONDecoder+JSObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = A725DEEB27D1553D00109471 /* JSONDecoder+JSObject.swift */; };
-		A73E0FA2282DC2F500AE7C54 /* PubSub.swift in Sources */ = {isa = PBXBuildFile; fileRef = A73E0FA1282DC2F500AE7C54 /* PubSub.swift */; };
+		A73E0FA2282DC2F500AE7C54 /* PortalsPubSub.swift in Sources */ = {isa = PBXBuildFile; fileRef = A73E0FA1282DC2F500AE7C54 /* PortalsPubSub.swift */; };
 		A790000827ECC82E003C4607 /* PortalsPlugin+SwiftConcurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = A790000727ECC82E003C4607 /* PortalsPlugin+SwiftConcurrency.swift */; };
 		B33B474B517C32464093FB86 /* Pods_IonicPortals.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3EE95777F19A5CA2F2504747 /* Pods_IonicPortals.framework */; };
 		D4B988A7279F4E0A0036033A /* PortalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B988A6279F4E0A0036033A /* PortalView.swift */; };
@@ -57,7 +57,7 @@
 		A725DEEB27D1553D00109471 /* JSONDecoder+JSObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSONDecoder+JSObject.swift"; sourceTree = "<group>"; };
 		A73E0F9B282DA5E400AE7C54 /* Pods_IonicPortals.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Pods_IonicPortals.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A73E0F9D282DA5F900AE7C54 /* Pods_IonicPortalsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Pods_IonicPortalsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		A73E0FA1282DC2F500AE7C54 /* PubSub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PubSub.swift; sourceTree = "<group>"; };
+		A73E0FA1282DC2F500AE7C54 /* PortalsPubSub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalsPubSub.swift; sourceTree = "<group>"; };
 		A790000727ECC82E003C4607 /* PortalsPlugin+SwiftConcurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PortalsPlugin+SwiftConcurrency.swift"; sourceTree = "<group>"; };
 		C6C8C717F3A70899030A3FFC /* Pods-IonicPortals.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IonicPortals.debug.xcconfig"; path = "Target Support Files/Pods-IonicPortals/Pods-IonicPortals.debug.xcconfig"; sourceTree = "<group>"; };
 		D4B9889F279F451A0036033A /* Capacitor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Capacitor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -163,7 +163,7 @@
 				A790000727ECC82E003C4607 /* PortalsPlugin+SwiftConcurrency.swift */,
 				55F6736426C2C097001E7AB9 /* PortalUIView.swift */,
 				D4B988A6279F4E0A0036033A /* PortalView.swift */,
-				A73E0FA1282DC2F500AE7C54 /* PubSub.swift */,
+				A73E0FA1282DC2F500AE7C54 /* PortalsPubSub.swift */,
 				5564A84B26DE8909000AF010 /* UnregisteredView.swift */,
 				5564A84D26DE8D31000AF010 /* UnregisteredView.xib */,
 			);
@@ -358,7 +358,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A73E0FA2282DC2F500AE7C54 /* PubSub.swift in Sources */,
+				A73E0FA2282DC2F500AE7C54 /* PortalsPubSub.swift in Sources */,
 				5564A84C26DE8909000AF010 /* UnregisteredView.swift in Sources */,
 				E90B7D5026A9CB880067D73E /* PortalManager.swift in Sources */,
 				A790000827ECC82E003C4607 /* PortalsPlugin+SwiftConcurrency.swift in Sources */,

--- a/IonicPortals/IonicPortals.xcodeproj/project.pbxproj
+++ b/IonicPortals/IonicPortals.xcodeproj/project.pbxproj
@@ -14,12 +14,15 @@
 		5564A85226DFE5D1000AF010 /* images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5564A85126DFE5D1000AF010 /* images.xcassets */; };
 		55F6736526C2C098001E7AB9 /* PortalUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F6736426C2C097001E7AB9 /* PortalUIView.swift */; };
 		9FE6157156CCFAE2EB45C746 /* Pods_IonicPortalsTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 75B0295D16569AE72DF5E457 /* Pods_IonicPortalsTests.framework */; };
+		A6B29E5927E94ADA9EFEF655 /* Pods_IonicPortalsTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A73E0F9D282DA5F900AE7C54 /* Pods_IonicPortalsTests.framework */; };
 		A725DEE627D0266100109471 /* PortalsPlugin+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A725DEE527D0266100109471 /* PortalsPlugin+Combine.swift */; };
 		A725DEEA27D1548C00109471 /* JSONEncoder+JSObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = A725DEE927D1548C00109471 /* JSONEncoder+JSObject.swift */; };
 		A725DEEC27D1553D00109471 /* JSONDecoder+JSObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = A725DEEB27D1553D00109471 /* JSONDecoder+JSObject.swift */; };
+		A73E0FA2282DC2F500AE7C54 /* PubSub.swift in Sources */ = {isa = PBXBuildFile; fileRef = A73E0FA1282DC2F500AE7C54 /* PubSub.swift */; };
 		A790000827ECC82E003C4607 /* PortalsPlugin+SwiftConcurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = A790000727ECC82E003C4607 /* PortalsPlugin+SwiftConcurrency.swift */; };
 		B33B474B517C32464093FB86 /* Pods_IonicPortals.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3EE95777F19A5CA2F2504747 /* Pods_IonicPortals.framework */; };
 		D4B988A7279F4E0A0036033A /* PortalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B988A6279F4E0A0036033A /* PortalView.swift */; };
+		DA5852DFE77B6E4ECD5903EC /* Pods_IonicPortals.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A73E0F9B282DA5E400AE7C54 /* Pods_IonicPortals.framework */; };
 		E90B7D5026A9CB880067D73E /* PortalManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E90B7D4F26A9CB880067D73E /* PortalManager.swift */; };
 		E985F88A269E2D260031F820 /* IonicPortals.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E985F880269E2D260031F820 /* IonicPortals.framework */; };
 		E985F88F269E2D260031F820 /* PortalsPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E985F88E269E2D260031F820 /* PortalsPluginTests.swift */; };
@@ -47,15 +50,20 @@
 		5564A85126DFE5D1000AF010 /* images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = images.xcassets; sourceTree = "<group>"; };
 		55F6736426C2C097001E7AB9 /* PortalUIView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PortalUIView.swift; sourceTree = "<group>"; };
 		75B0295D16569AE72DF5E457 /* Pods_IonicPortalsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IonicPortalsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		767B8C4897813E2A7432D452 /* Pods-IonicPortalsObjcTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IonicPortalsObjcTests.debug.xcconfig"; path = "Target Support Files/Pods-IonicPortalsObjcTests/Pods-IonicPortalsObjcTests.debug.xcconfig"; sourceTree = "<group>"; };
 		806037FB6C3994ECAB6FB38F /* Pods-IonicPortalsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IonicPortalsTests.debug.xcconfig"; path = "Target Support Files/Pods-IonicPortalsTests/Pods-IonicPortalsTests.debug.xcconfig"; sourceTree = "<group>"; };
 		A725DEE527D0266100109471 /* PortalsPlugin+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PortalsPlugin+Combine.swift"; sourceTree = "<group>"; };
 		A725DEE927D1548C00109471 /* JSONEncoder+JSObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSONEncoder+JSObject.swift"; sourceTree = "<group>"; };
 		A725DEEB27D1553D00109471 /* JSONDecoder+JSObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSONDecoder+JSObject.swift"; sourceTree = "<group>"; };
+		A73E0F9B282DA5E400AE7C54 /* Pods_IonicPortals.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Pods_IonicPortals.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A73E0F9D282DA5F900AE7C54 /* Pods_IonicPortalsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Pods_IonicPortalsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A73E0FA1282DC2F500AE7C54 /* PubSub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PubSub.swift; sourceTree = "<group>"; };
 		A790000727ECC82E003C4607 /* PortalsPlugin+SwiftConcurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PortalsPlugin+SwiftConcurrency.swift"; sourceTree = "<group>"; };
 		C6C8C717F3A70899030A3FFC /* Pods-IonicPortals.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IonicPortals.debug.xcconfig"; path = "Target Support Files/Pods-IonicPortals/Pods-IonicPortals.debug.xcconfig"; sourceTree = "<group>"; };
 		D4B9889F279F451A0036033A /* Capacitor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Capacitor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4B988A0279F451A0036033A /* Cordova.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Cordova.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4B988A6279F4E0A0036033A /* PortalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalView.swift; sourceTree = "<group>"; };
+		D8A4E0C49B293D896836DE47 /* Pods-IonicPortalsObjcTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IonicPortalsObjcTests.release.xcconfig"; path = "Target Support Files/Pods-IonicPortalsObjcTests/Pods-IonicPortalsObjcTests.release.xcconfig"; sourceTree = "<group>"; };
 		E90B7D4F26A9CB880067D73E /* PortalManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PortalManager.swift; sourceTree = "<group>"; };
 		E985F880269E2D260031F820 /* IonicPortals.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = IonicPortals.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E985F883269E2D260031F820 /* IonicPortals.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IonicPortals.h; sourceTree = "<group>"; };
@@ -65,6 +73,7 @@
 		E985F890269E2D260031F820 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E985F89E269E2D830031F820 /* Portal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Portal.swift; sourceTree = "<group>"; };
 		EA5BBE1015F84D166BA030C4 /* Pods-IonicPortals.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IonicPortals.release.xcconfig"; path = "Target Support Files/Pods-IonicPortals/Pods-IonicPortals.release.xcconfig"; sourceTree = "<group>"; };
+		EBB1A9E69B05F6D619260B9F /* Pods_IonicPortalsObjcTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IonicPortalsObjcTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -73,6 +82,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B33B474B517C32464093FB86 /* Pods_IonicPortals.framework in Frameworks */,
+				DA5852DFE77B6E4ECD5903EC /* Pods_IonicPortals.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -82,6 +92,7 @@
 			files = (
 				E985F88A269E2D260031F820 /* IonicPortals.framework in Frameworks */,
 				9FE6157156CCFAE2EB45C746 /* Pods_IonicPortalsTests.framework in Frameworks */,
+				A6B29E5927E94ADA9EFEF655 /* Pods_IonicPortalsTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -91,10 +102,13 @@
 		1F249143665D3AA4301AD1DE /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				A73E0F9D282DA5F900AE7C54 /* Pods_IonicPortalsTests.framework */,
+				A73E0F9B282DA5E400AE7C54 /* Pods_IonicPortals.framework */,
 				D4B9889F279F451A0036033A /* Capacitor.framework */,
 				D4B988A0279F451A0036033A /* Cordova.framework */,
 				3EE95777F19A5CA2F2504747 /* Pods_IonicPortals.framework */,
 				75B0295D16569AE72DF5E457 /* Pods_IonicPortalsTests.framework */,
+				EBB1A9E69B05F6D619260B9F /* Pods_IonicPortalsObjcTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -106,6 +120,8 @@
 				EA5BBE1015F84D166BA030C4 /* Pods-IonicPortals.release.xcconfig */,
 				806037FB6C3994ECAB6FB38F /* Pods-IonicPortalsTests.debug.xcconfig */,
 				4FEEEE4E212525F74B4F50FF /* Pods-IonicPortalsTests.release.xcconfig */,
+				767B8C4897813E2A7432D452 /* Pods-IonicPortalsObjcTests.debug.xcconfig */,
+				D8A4E0C49B293D896836DE47 /* Pods-IonicPortalsObjcTests.release.xcconfig */,
 			);
 			name = Pods;
 			path = ../Pods;
@@ -134,21 +150,22 @@
 		E985F882269E2D260031F820 /* IonicPortals */ = {
 			isa = PBXGroup;
 			children = (
+				5564A85126DFE5D1000AF010 /* images.xcassets */,
+				E985F884269E2D260031F820 /* Info.plist */,
+				E985F883269E2D260031F820 /* IonicPortals.h */,
+				A725DEEB27D1553D00109471 /* JSONDecoder+JSObject.swift */,
+				A725DEE927D1548C00109471 /* JSONEncoder+JSObject.swift */,
+				E985F89E269E2D830031F820 /* Portal.swift */,
 				E90B7D4F26A9CB880067D73E /* PortalManager.swift */,
-				55F6736426C2C097001E7AB9 /* PortalUIView.swift */,
 				55113DAB26D4596500BD3C9B /* PortalsPlugin.m */,
 				55113DAC26D4596500BD3C9B /* PortalsPlugin.swift */,
-				E985F89E269E2D830031F820 /* Portal.swift */,
-				E985F883269E2D260031F820 /* IonicPortals.h */,
-				E985F884269E2D260031F820 /* Info.plist */,
-				5564A84B26DE8909000AF010 /* UnregisteredView.swift */,
-				5564A84D26DE8D31000AF010 /* UnregisteredView.xib */,
-				5564A85126DFE5D1000AF010 /* images.xcassets */,
-				D4B988A6279F4E0A0036033A /* PortalView.swift */,
 				A725DEE527D0266100109471 /* PortalsPlugin+Combine.swift */,
 				A790000727ECC82E003C4607 /* PortalsPlugin+SwiftConcurrency.swift */,
-				A725DEE927D1548C00109471 /* JSONEncoder+JSObject.swift */,
-				A725DEEB27D1553D00109471 /* JSONDecoder+JSObject.swift */,
+				55F6736426C2C097001E7AB9 /* PortalUIView.swift */,
+				D4B988A6279F4E0A0036033A /* PortalView.swift */,
+				A73E0FA1282DC2F500AE7C54 /* PubSub.swift */,
+				5564A84B26DE8909000AF010 /* UnregisteredView.swift */,
+				5564A84D26DE8D31000AF010 /* UnregisteredView.xib */,
 			);
 			path = IonicPortals;
 			sourceTree = "<group>";
@@ -230,6 +247,7 @@
 					};
 					E985F888269E2D260031F820 = {
 						CreatedOnToolsVersion = 12.5.1;
+						LastSwiftMigration = 1330;
 					};
 				};
 			};
@@ -340,6 +358,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A73E0FA2282DC2F500AE7C54 /* PubSub.swift in Sources */,
 				5564A84C26DE8909000AF010 /* UnregisteredView.swift in Sources */,
 				E90B7D5026A9CB880067D73E /* PortalManager.swift in Sources */,
 				A790000827ECC82E003C4607 /* PortalsPlugin+SwiftConcurrency.swift in Sources */,
@@ -565,6 +584,7 @@
 			baseConfigurationReference = 806037FB6C3994ECAB6FB38F /* Pods-IonicPortalsTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 9YN2HU59K8;
 				INFOPLIST_FILE = IonicPortalsTests/Info.plist;
@@ -576,6 +596,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.ionic.IonicPortalsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -586,6 +607,7 @@
 			baseConfigurationReference = 4FEEEE4E212525F74B4F50FF /* Pods-IonicPortalsTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 9YN2HU59K8;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -598,6 +620,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.ionic.IonicPortalsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/IonicPortals/IonicPortals/IonicPortals.h
+++ b/IonicPortals/IonicPortals/IonicPortals.h
@@ -14,5 +14,3 @@ FOUNDATION_EXPORT double IonicPortalsVersionNumber;
 FOUNDATION_EXPORT const unsigned char IonicPortalsVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <IonicPortals/PublicHeader.h>
-
-

--- a/IonicPortals/IonicPortals/Portal.swift
+++ b/IonicPortals/IonicPortals/Portal.swift
@@ -1,19 +1,87 @@
 import Foundation
+import Capacitor
 import IonicLiveUpdates
 
-@objc(Portal)
-public class Portal: NSObject {
+/// The configuration of a web application to be embedded in an iOS application
+public struct Portal {
     
-    // MARK: - Instance Properties
-    public let name: String;
-    public var initialContext: Dictionary<String, Any>?
-    public var startDir: String?
+    /// The name of the portal
+    public let name: String
     
-    public var liveUpdateConfig: LiveUpdate? = nil
+    /// The root directory of the ``Portal`` relative to root of the `Bundle`
+    public let startDir: String
     
-    public init(_ name: String, _ startDir: String?) {
+    /// Any initial state required by the web application
+    public var initialContext: [String: JSValue]
+    
+    /// The `LiveUpdate` configuration used to determine the location of updated application assets.
+    public var liveUpdateConfig: LiveUpdate? = nil {
+        didSet {
+            guard let liveUpdateConfig = liveUpdateConfig else { return }
+            try? LiveUpdateManager.shared.add(liveUpdateConfig)
+        }
+    }
+    
+    /// Creates an instance of ``Portal``
+    /// - Parameters:
+    ///   - name: The name of the portal, must be unique.
+    ///   - startDir: The starting directory of the ``Portal`` relative to the root of the ``Bundle``.
+    ///     If `nil`, the portal name is used as the starting directory. Defaults to `nil`.
+    ///   - initialContext: Any initial state rqeuired by the web application. Defaults to `[:]`.
+    ///   - liveUpdateConfig: The `LiveUpdate` configuration used to determine to location of updated application assets. Defaults to `nil`.
+    public init(name: String, startDir: String? = nil, initialContext: [String: JSValue] = [:], liveUpdateConfig: LiveUpdate? = nil) {
         self.name = name
         self.startDir = startDir ?? name
+        self.initialContext = initialContext
+        self.liveUpdateConfig = liveUpdateConfig
+        if let liveUpdateConfig = liveUpdateConfig {
+            try? LiveUpdateManager.shared.add(liveUpdateConfig)
+        }
     }
 }
 
+/// The objective-c representation of ``Portal``
+@objc public class IONPortal: NSObject {
+    internal var portal: Portal
+    
+    /// The name of the portal
+    @objc public var name: String { portal.name }
+    
+    /// The root directory of the ``Portal`` relative to root of the `Bundle`
+    @objc public var startDir: String { portal.startDir }
+    
+    /// Any initial state required by the web application
+    @objc public var initialContext: [String: Any] {
+        get { portal.initialContext }
+        set {
+            guard let context = newValue as? [String: JSValue] else { return }
+            portal.initialContext = context
+        }
+    }
+    
+    internal init(portal: Portal) {
+        self.portal = portal
+    }
+    
+    /// Configures the `LiveUpdate` configuration
+    /// - Parameters:
+    ///   - appId: The AppFlow id of the web application associated with the ``IONPortal``
+    ///   - channel: The AppFlow channel to check for updates from.
+    ///   - syncImmediately: Whether to immediately sync with AppFlow to check for updates.
+    @objc public func setLiveUpdateConfiguration(appId: String, channel: String, syncImmediately: Bool) {
+        portal.liveUpdateConfig = LiveUpdate(appId: appId, channel: channel, syncOnAdd: syncImmediately)
+    }
+}
+
+extension IONPortal {
+    /// Creates an instance of ``Portal``
+    /// - Parameters:
+    ///   - name: The name of the portal, must be unique.
+    ///   - startDir: The starting directory of the ``Portal`` relative to the root of the ``Bundle``.
+    ///     If `nil`, the portal name is used as the starting directory.
+    ///   - initialContext: Any initial state rqeuired by the web application. Defaults to `[:]`.
+    @objc public convenience init(name: String, startDir: String?, initialContext: [String: Any]?) {
+        let portal = Portal(name: name, startDir: startDir, initialContext: initialContext as? [String: JSValue] ?? [:], liveUpdateConfig: nil)
+        self.init(portal: portal)
+    }
+}

--- a/IonicPortals/IonicPortals/Portal.swift
+++ b/IonicPortals/IonicPortals/Portal.swift
@@ -40,7 +40,7 @@ public struct Portal {
     }
 }
 
-/// The objective-c representation of ``Portal``
+/// The objective-c representation of ``Portal``. If using Swift, ``Portal`` is preferred since it provides better type constraints.
 @objc public class IONPortal: NSObject {
     internal var portal: Portal
     
@@ -50,7 +50,15 @@ public struct Portal {
     /// The root directory of the ``Portal`` relative to root of the `Bundle`
     @objc public var startDir: String { portal.startDir }
     
-    /// Any initial state required by the web application
+    /// Any initial state required by the web application.
+    ///
+    /// The following types are valid values:
+    /// * NSNumber
+    /// * NSString
+    /// * NSArray
+    /// * NSDate
+    /// * NSNull
+    /// * NSDictionary keyed by a String and the value is any valid JS Value
     @objc public var initialContext: [String: Any] {
         get { portal.initialContext }
         set {
@@ -80,6 +88,14 @@ extension IONPortal {
     ///   - startDir: The starting directory of the ``Portal`` relative to the root of the ``Bundle``.
     ///     If `nil`, the portal name is used as the starting directory.
     ///   - initialContext: Any initial state rqeuired by the web application. Defaults to `[:]`.
+    ///
+    /// The following types are valid values in `initialContext`:
+    /// * NSNumber
+    /// * NSString
+    /// * NSArray
+    /// * NSDate
+    /// * NSNull
+    /// * NSDictionary keyed by a String and the value is any valid JS Value
     @objc public convenience init(name: String, startDir: String?, initialContext: [String: Any]?) {
         let portal = Portal(name: name, startDir: startDir, initialContext: initialContext as? [String: JSValue] ?? [:], liveUpdateConfig: nil)
         self.init(portal: portal)

--- a/IonicPortals/IonicPortals/PortalManager.swift
+++ b/IonicPortals/IonicPortals/PortalManager.swift
@@ -2,7 +2,7 @@ import Foundation
 import UIKit
 
 /// Maintains a registry of ``Portal``s for the lifecycle of an application
-@objc(PortalManager)
+@objc(IONPortalManager)
 public class PortalManager: NSObject {
     enum RegistrationState {
         case unregistered(messageShown: Bool)
@@ -34,7 +34,7 @@ public class PortalManager: NSObject {
     
     /// Adds a ``Portal`` to ``PortalManager``
     /// - Parameter portal: The ``Portal`` to add
-    @objc public func add(_ portal: Portal) {
+    public func add(_ portal: Portal) {
         portals[portal.name] = portal
         
         if case .unregistered(messageShown: false) = registrationState {
@@ -42,17 +42,35 @@ public class PortalManager: NSObject {
         }
     }
     
+    /// Adds an ``IONPortal`` to ``PortalManager``
+    /// - Parameter portal: The ``IONPortal`` to add
+    ///
+    /// This method is meant to be used for Objective-C interop. The ``add(_:)`` method is preferred if being called from Swift
+    @objc public func addPortal(_ portal: IONPortal) {
+        add(portal.portal)
+    }
+    
     /// Returns a ``Portal`` given the name of the portal
     /// - Parameter name: The Portal name
     /// - returns: The existing ``Portal`` with name `name`.
-    /// Returns `nil` if the ``Portal`` has not been added via ``add(_:)``, created through ``newPortal(named:)``, or if a registration error has occured
-    @objc public func getPortal(named name: String) -> Portal? {
+    /// Returns `nil` if the ``Portal`` has not been added via ``add(_:)`` or if a registration error has occured
+    public func getPortal(named name: String) -> Portal? {
         if case .error = registrationState {
             registrationError()
             return nil
         }
         
         return portals[name]
+    }
+    
+    /// Returns an ``IONPortal`` given the name of the portal
+    /// - Parameter name: The IONPortal name
+    /// - returns: The existing ``IONPortal`` with name `name`.
+    /// Returns `nil` if the ``IONPortal`` has not been added via ``add(_:)``, ``addPortal(_:)``, or if a registration error has occured
+    ///
+    /// This method is meant to be used for Objective-C interop. The ``getPortal(named:)`` method is preferred if being called from Swift.
+    @objc public func getPortalNamed(_ name: String) -> IONPortal? {
+        getPortal(named: name).map(IONPortal.init(portal:))
     }
     
     /// Validates that a valid registration key has been procured from http://ionic.io/register-portals

--- a/IonicPortals/IonicPortals/PortalUIView.swift
+++ b/IonicPortals/IonicPortals/PortalUIView.swift
@@ -5,7 +5,7 @@ import Capacitor
 import IonicLiveUpdates
 
 /// A UIKit UIView to display ``Portal`` content
-@objc(PortalUIView)
+@objc(IONPortalUIView)
 public class PortalUIView: UIView {
     lazy var webView = InternalCapWebView(portal: portal, liveUpdatePath: liveUpdatePath)
     var portal: Portal
@@ -16,10 +16,16 @@ public class PortalUIView: UIView {
     
     /// Creates an instance of ``PortalUIView``
     /// - Parameter portal: The ``Portal`` to render.
-    @objc public init(portal: Portal) {
+    public init(portal: Portal) {
         self.portal = portal
         super.init(frame: .zero)
         initView()
+    }
+    
+    /// Creates an instance of ``PortalUIView``
+    /// - Parameter portal: The ``IONPortal`` to render.
+    @objc public convenience init(portal: IONPortal) {
+        self.init(portal: portal.portal)
     }
     
     required init?(coder: NSCoder) {
@@ -91,7 +97,7 @@ public class PortalUIView: UIView {
         }
         
         override func loadInitialContext(_ userContentViewController: WKUserContentController) {
-            guard let jsonData = try? JSONSerialization.data(withJSONObject: portal.initialContext ?? [:]) else { return }
+            guard portal.initialContext.isNotEmpty, let jsonData = try? JSONSerialization.data(withJSONObject: portal.initialContext) else { return }
                 
             let jsonString = String(data: jsonData, encoding: .utf8) ?? ""
             let portalInitialContext = #"{ "name": "\#(portal.name)", "value": \#(jsonString) }"#
@@ -107,6 +113,10 @@ public class PortalUIView: UIView {
         }
     }
     
+}
+
+extension Collection {
+    var isNotEmpty: Bool { !isEmpty }
 }
 
 extension UIView {

--- a/IonicPortals/IonicPortals/PortalsPlugin+Combine.swift
+++ b/IonicPortals/IonicPortals/PortalsPlugin+Combine.swift
@@ -9,7 +9,7 @@ import Foundation
 import Combine
 import Capacitor
 
-extension PubSub {
+extension PortalsPubSub {
     public struct Publisher: Combine.Publisher {
         let topic: String
         
@@ -35,7 +35,7 @@ extension PubSub {
         where S: Subscriber, S.Input == SubscriptionResult, S.Failure == Never {
             self.subscriber = AnySubscriber(subscriber)
             self.topic = topic
-            subscriptionReference = PubSub.subscribe(topic) { [weak self] result in
+            subscriptionReference = PortalsPubSub.subscribe(topic) { [weak self] result in
                 _ = self?.subscriber.receive(result)
             }
         }
@@ -52,7 +52,7 @@ extension PubSub {
         
         func cancel() {
             guard let ref = subscriptionReference else { return }
-            PubSub.unsubscribe(from: topic, subscriptionRef: ref)
+            PortalsPubSub.unsubscribe(from: topic, subscriptionRef: ref)
         }
     }
     
@@ -64,7 +64,7 @@ extension PubSub {
     }
 }
 
-extension PubSub.Publisher {
+extension PortalsPubSub.Publisher {
     
     /// Error to be thrown when cating from JSValue to concrete value fails
     public struct CastingError<T>: Error, CustomStringConvertible {

--- a/IonicPortals/IonicPortals/PortalsPlugin+Combine.swift
+++ b/IonicPortals/IonicPortals/PortalsPlugin+Combine.swift
@@ -9,7 +9,7 @@ import Foundation
 import Combine
 import Capacitor
 
-extension PortalsPlugin {
+extension PubSub {
     public struct Publisher: Combine.Publisher {
         let topic: String
         
@@ -35,7 +35,7 @@ extension PortalsPlugin {
         where S: Subscriber, S.Input == SubscriptionResult, S.Failure == Never {
             self.subscriber = AnySubscriber(subscriber)
             self.topic = topic
-            subscriptionReference = PortalsPlugin.subscribe(topic) { [weak self] result in
+            subscriptionReference = PubSub.subscribe(topic) { [weak self] result in
                 _ = self?.subscriber.receive(result)
             }
         }
@@ -52,7 +52,7 @@ extension PortalsPlugin {
         
         func cancel() {
             guard let ref = subscriptionReference else { return }
-            PortalsPlugin.unsubscribe(topic, ref)
+            PubSub.unsubscribe(from: topic, subscriptionRef: ref)
         }
     }
     
@@ -64,7 +64,7 @@ extension PortalsPlugin {
     }
 }
 
-extension PortalsPlugin.Publisher {
+extension PubSub.Publisher {
     
     /// Error to be thrown when cating from JSValue to concrete value fails
     public struct CastingError<T>: Error, CustomStringConvertible {
@@ -73,7 +73,7 @@ extension PortalsPlugin.Publisher {
     
     /// Extracts the ``SubscriptionResult/data`` value from ``SubscriptionResult``
     /// - Returns: A publisher emitting the ``SubscriptionResult/data`` value from the upstream ``SubscriptionResult``
-    public func data() -> AnyPublisher<JSValue, Never> {
+    public func data() -> AnyPublisher<JSValue?, Never> {
         map(\.data)
             .eraseToAnyPublisher()
     }

--- a/IonicPortals/IonicPortals/PortalsPlugin+SwiftConcurrency.swift
+++ b/IonicPortals/IonicPortals/PortalsPlugin+SwiftConcurrency.swift
@@ -8,18 +8,18 @@
 import Foundation
 
 #if compiler(>=5.6) && canImport(_Concurrency)
-extension PubSub {
+extension PortalsPubSub {
     /// Subscribe to a topic and receive the events in an `AsyncStream`
     /// - Parameter topic: The topic to subscribe to
     /// - Returns: An AsyncStream emitting ``SubscriptionResult``
     public static func subscribe(_ topic: String) -> AsyncStream<SubscriptionResult> {
         AsyncStream { continuation in
-            let ref = PubSub.subscribe(topic) { result in
+            let ref = PortalsPubSub.subscribe(topic) { result in
                 continuation.yield(result)
             }
             
             continuation.onTermination = { @Sendable _ in
-                PubSub.unsubscribe(from: topic, subscriptionRef: ref)
+                PortalsPubSub.unsubscribe(from: topic, subscriptionRef: ref)
             }
         }
     }

--- a/IonicPortals/IonicPortals/PortalsPlugin+SwiftConcurrency.swift
+++ b/IonicPortals/IonicPortals/PortalsPlugin+SwiftConcurrency.swift
@@ -8,18 +8,18 @@
 import Foundation
 
 #if compiler(>=5.6) && canImport(_Concurrency)
-extension PortalsPlugin {
+extension PubSub {
     /// Subscribe to a topic and receive the events in an `AsyncStream`
     /// - Parameter topic: The topic to subscribe to
     /// - Returns: An AsyncStream emitting ``SubscriptionResult``
     public static func subscribe(_ topic: String) -> AsyncStream<SubscriptionResult> {
         AsyncStream { continuation in
-            let ref = PortalsPlugin.subscribe(topic) { result in
+            let ref = PubSub.subscribe(topic) { result in
                 continuation.yield(result)
             }
             
             continuation.onTermination = { @Sendable _ in
-                PortalsPlugin.unsubscribe(topic, ref)
+                PubSub.unsubscribe(from: topic, subscriptionRef: ref)
             }
         }
     }

--- a/IonicPortals/IonicPortals/PortalsPlugin.m
+++ b/IonicPortals/IonicPortals/PortalsPlugin.m
@@ -1,6 +1,6 @@
 #import <Capacitor/Capacitor.h>
 
-CAP_PLUGIN(PortalsPlugin, "Portals",
+CAP_PLUGIN(IONPortalsPlugin, "Portals",
   CAP_PLUGIN_METHOD(publishNative, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(subscribeNative, CAPPluginReturnCallback);
   CAP_PLUGIN_METHOD(unsubscribeNative, CAPPluginReturnPromise);

--- a/IonicPortals/IonicPortals/PortalsPlugin.swift
+++ b/IonicPortals/IonicPortals/PortalsPlugin.swift
@@ -10,7 +10,7 @@ internal class Plugin: CAPPlugin {
         }
         
         let data = call.getValue("data")
-        PubSub.publish(topic, message: data)
+        PortalsPubSub.publish(topic, message: data)
         call.resolve()
     }
     
@@ -21,7 +21,7 @@ internal class Plugin: CAPPlugin {
         }
         call.keepAlive = true
         
-        let ref = IONPubSub.subscribe(topic: topic, callback: call.resolve)
+        let ref = IONPortalsPubSub.subscribe(topic: topic, callback: call.resolve)
         call.resolve([
             "topic": topic,
             "subscriptionRef": ref
@@ -37,7 +37,7 @@ internal class Plugin: CAPPlugin {
             call.reject("subscriptionRef not provided")
             return
         }
-        PubSub.unsubscribe(from: topic, subscriptionRef: subscriptionRef)
+        PortalsPubSub.unsubscribe(from: topic, subscriptionRef: subscriptionRef)
         call.resolve()
     }
     

--- a/IonicPortals/IonicPortals/PortalsPlugin.swift
+++ b/IonicPortals/IonicPortals/PortalsPlugin.swift
@@ -2,23 +2,15 @@ import Foundation
 import Capacitor
 import Combine
 
-/// An interface that enables marshalling data to and from a ``Portal`` over an event bus
-@objc(PortalsPlugin)
-public class PortalsPlugin: CAPPlugin {
-    private static let queue = DispatchQueue(label: "io.ionic.portals.pubsub", attributes: .concurrent)
-    
-    private static var subscriptions: [String: [Int: (SubscriptionResult) -> Void]] = [:]
-    private static var subscriptionRef = 0
-    
-    // MARK: Methods used by Cap Plugin
-
+@objc(IONPortalsPlugin)
+internal class Plugin: CAPPlugin {
     @objc func publishNative(_ call: CAPPluginCall) {
         guard let topic = call.getString("topic") else {
-            call.reject("topic not provided")
-            return
+            return call.reject("topic not provided")
         }
+        
         let data = call.getValue("data")
-        PortalsPlugin.publish(topic, data!)
+        PubSub.publish(topic, message: data)
         call.resolve()
     }
     
@@ -28,9 +20,8 @@ public class PortalsPlugin: CAPPlugin {
             return
         }
         call.keepAlive = true
-        let ref = PortalsPlugin.subscribe(topic, {result in
-            call.resolve(result.dictionaryRepresentation)
-        })
+        
+        let ref = IONPubSub.subscribe(topic: topic, callback: call.resolve)
         call.resolve([
             "topic": topic,
             "subscriptionRef": ref
@@ -46,89 +37,9 @@ public class PortalsPlugin: CAPPlugin {
             call.reject("subscriptionRef not provided")
             return
         }
-        PortalsPlugin.unsubscribe(topic, subscriptionRef)
+        PubSub.unsubscribe(from: topic, subscriptionRef: subscriptionRef)
         call.resolve()
     }
     
-    // MARK: Static methods for use by Swift app
-    
-    /// Subscribe to a topic and execute the provided callback when the event is received.
-    /// - Parameters:
-    ///   - topic: The topic to listen for events on
-    ///   - callback: The code to be executed when an event is received for the topic
-    /// - Returns: A subscription reference to use for unsubscribing
-    /// > Tip: Using this method requires you to call ``unsubscribe(_:_:)`` when finished.
-    /// Use ``subscribe(to:_:)`` to get an `AnyCancellable` that will automatically unsubscribe from the topic on deallocation.
-    public static func subscribe(_ topic: String, _ callback: @escaping (SubscriptionResult) -> Void) -> Int {
-        queue.sync {
-            subscriptionRef += 1
-            
-            if var subscription = subscriptions[topic] {
-                subscription[subscriptionRef] = callback
-                subscriptions[topic] = subscription
-            } else {
-                let subscription = [subscriptionRef : callback]
-                subscriptions[topic] = subscription
-            }
-            
-            return subscriptionRef
-        }
-    }
-    
-    
-    /// Subscribe to a topic and execute the provided callback when the event is received.
-    /// - Parameters:
-    ///   - topic: The topic to listen for events on
-    ///   - callback: The code to be executed when an event is received for the topic
-    /// - Returns: An `AnyCancellable` that unsubscribes from the topic when deallocated.
-    public static func subscribe(to topic: String, _ callback: @escaping (SubscriptionResult) -> Void) -> AnyCancellable {
-        let ref = subscribe(topic, callback)
-        return AnyCancellable { PortalsPlugin.unsubscribe(topic, ref) }
-    }
-    
-    /// Publish event to all listeners of a topic
-    /// - Parameters:
-    ///   - topic: The topic to publish to
-    ///   - data: The data to deliver to all subscribers. Must be a valid JSON data type.
-    public static func publish(_ topic: String, _ data: JSValue) {
-        queue.sync {
-            if let subscription = subscriptions[topic] {
-                for (ref, listener) in subscription {
-                    let result = SubscriptionResult(topic: topic, data: data, subscriptionRef: ref)
-                    listener(result)
-                }
-            }
-        }
-    }
-    
-    /// Stop receiving events. This must must be called to prevent a closure from being executed indefinitely
-    /// - Parameters:
-    ///   - topic: The topic to unsubscribe from
-    ///   - subscriptionRef: The subscriptionRef provided during subscription
-    public static func unsubscribe(_ topic: String, _ subscriptionRef: Int) {
-        queue.async(flags: .barrier) {
-            if var subscription = subscriptions[topic] {
-                subscription[subscriptionRef] = nil
-                subscriptions[topic] = subscription
-            }
-        }
-    }
 }
 
-/// The data emitted to a subscriber
-public struct SubscriptionResult {
-    /// The topic the ``SubscriptionResult`` was emitted on
-    public var topic: String
-    /// The value emitted
-    public var data: JSValue
-    /// The reference to the subscription. Used for calling ``PortalsPlugin/unsubscribe(_:_:)``
-    public var subscriptionRef: Int
-    
-    var dictionaryRepresentation: [String: JSValue] {
-        return [
-            "topic": topic,
-            "data": data,
-            "subscriptionRef": subscriptionRef
-        ]
-    }
-}

--- a/IonicPortals/IonicPortals/PortalsPubSub.swift
+++ b/IonicPortals/IonicPortals/PortalsPubSub.swift
@@ -1,5 +1,5 @@
 //
-//  PubSub.swift
+//  PortalsPubSub.swift
 //  IonicPortals
 //
 //  Created by Steven Sherry on 5/12/22.
@@ -10,7 +10,7 @@ import Combine
 import Capacitor
 
 /// An interface that enables marshalling data to and from a ``Portal`` over an event bus
-public enum PubSub {
+public enum PortalsPubSub {
     private static let queue = DispatchQueue(label: "io.ionic.portals.pubsub", attributes: .concurrent)
     
     private static var subscriptions: [String: [Int: (SubscriptionResult) -> Void]] = [:]
@@ -98,7 +98,7 @@ public struct SubscriptionResult {
 }
 
 /// An objective-c interface that enables marshalling data to and from a ``Portal`` over an event bus
-@objc public class IONPubSub: NSObject {
+@objc public class IONPortalsPubSub: NSObject {
     private override init() { }
     
     /// Subscribe to a topic and execute the provided callback when the event is received.
@@ -108,18 +108,18 @@ public struct SubscriptionResult {
     /// - Returns: A subscription reference to use for unsubscribing
     /// > Tip: Using this method requires you to call ``unsubscribe(from:subscriptionRef:)`` when finished.
     @objc(subscribeToTopic:callback:) public static func subscribe(topic: String, callback: @escaping ([String: Any]) -> Void) -> Int {
-        PubSub.subscribe(topic) { result in
+        PortalsPubSub.subscribe(topic) { result in
             callback(result.dictionaryRepresentation as [String: Any])
         }
     }
         
     @objc(publishToTopic:data:) public static func publish(topic: String, data: Any) {
         guard let data = data as? JSValue else { return }
-        PubSub.publish(topic, message: data)
+        PortalsPubSub.publish(topic, message: data)
     }
     
     @objc(unsubscribeFromTopic:subscriptionRef:) public static func unsubscribe(_ topic: String, _ subscriptionRef: Int) {
-        PubSub.unsubscribe(from: topic, subscriptionRef: subscriptionRef)
+        PortalsPubSub.unsubscribe(from: topic, subscriptionRef: subscriptionRef)
     }
     
 }

--- a/IonicPortals/IonicPortals/PubSub.swift
+++ b/IonicPortals/IonicPortals/PubSub.swift
@@ -1,0 +1,125 @@
+//
+//  PubSub.swift
+//  IonicPortals
+//
+//  Created by Steven Sherry on 5/12/22.
+//
+
+import Foundation
+import Combine
+import Capacitor
+
+/// An interface that enables marshalling data to and from a ``Portal`` over an event bus
+public enum PubSub {
+    private static let queue = DispatchQueue(label: "io.ionic.portals.pubsub", attributes: .concurrent)
+    
+    private static var subscriptions: [String: [Int: (SubscriptionResult) -> Void]] = [:]
+    private static var subscriptionRef = 0
+    
+    /// Subscribe to a topic and execute the provided callback when the event is received.
+    /// - Parameters:
+    ///   - topic: The topic to listen for events on
+    ///   - callback: The code to be executed when an event is received for the topic
+    /// - Returns: A subscription reference to use for unsubscribing
+    /// > Tip: Using this method requires you to call ``unsubscribe(from:subscriptionRef:)`` when finished.
+    /// Use ``subscribe(to:_:)`` to get an `AnyCancellable` that will automatically unsubscribe from the topic on deallocation.
+    public static func subscribe(_ topic: String, _ callback: @escaping (SubscriptionResult) -> Void) -> Int {
+        queue.sync {
+            subscriptionRef += 1
+            
+            if var subscription = subscriptions[topic] {
+                subscription[subscriptionRef] = callback
+                subscriptions[topic] = subscription
+            } else {
+                let subscription = [subscriptionRef : callback]
+                subscriptions[topic] = subscription
+            }
+            
+            return subscriptionRef
+        }
+    }
+    
+    /// Subscribe to a topic and execute the provided callback when the event is received.
+    /// - Parameters:
+    ///   - topic: The topic to listen for events on
+    ///   - callback: The code to be executed when an event is received for the topic
+    /// - Returns: An `AnyCancellable` that unsubscribes from the topic when deallocated.
+    public static func subscribe(to topic: String, _ callback: @escaping (SubscriptionResult) -> Void) -> AnyCancellable {
+        let ref = subscribe(topic, callback)
+        return AnyCancellable { unsubscribe(from: topic, subscriptionRef: ref) }
+    }
+    
+    /// Publish event to all listeners of a topic
+    /// - Parameters:
+    ///   - topic: The topic to publish to
+    ///   - data: The data to deliver to all subscribers. Must be a valid JSON data type. Defaults to nil.
+    public static func publish(_ topic: String, message: JSValue? = nil) {
+        queue.sync {
+            if let subscription = subscriptions[topic] {
+                for (ref, listener) in subscription {
+                    let result = SubscriptionResult(topic: topic, data: message, subscriptionRef: ref)
+                    listener(result)
+                }
+            }
+        }
+    }
+    
+    /// Stop receiving events. This must must be called to prevent a closure from being executed indefinitely
+    /// - Parameters:
+    ///   - topic: The topic to unsubscribe from
+    ///   - subscriptionRef: The subscriptionRef provided during subscription
+    public static func unsubscribe(from topic: String, subscriptionRef: Int) {
+        queue.async(flags: .barrier) {
+            if var subscription = subscriptions[topic] {
+                subscription[subscriptionRef] = nil
+                subscriptions[topic] = subscription
+            }
+        }
+    }
+    
+}
+
+/// The data emitted to a subscriber
+public struct SubscriptionResult {
+    /// The topic the ``SubscriptionResult`` was emitted on
+    public var topic: String
+    /// The value emitted
+    public var data: JSValue?
+    /// The reference to the subscription. Used for calling ``PubSub/unsubscribe(from:subscriptionRef:)``
+    public var subscriptionRef: Int
+    
+    var dictionaryRepresentation: [String: JSValue?] {
+        return [
+            "topic": topic,
+            "data": data,
+            "subscriptionRef": subscriptionRef
+        ]
+    }
+}
+
+/// An objective-c interface that enables marshalling data to and from a ``Portal`` over an event bus
+@objc public class IONPubSub: NSObject {
+    private override init() { }
+    
+    /// Subscribe to a topic and execute the provided callback when the event is received.
+    /// - Parameters:
+    ///   - topic: The topic to listen for events on
+    ///   - callback: The code to be executed when an event is received for the topic
+    /// - Returns: A subscription reference to use for unsubscribing
+    /// > Tip: Using this method requires you to call ``unsubscribe(from:subscriptionRef:)`` when finished.
+    @objc(subscribeToTopic:callback:) public static func subscribe(topic: String, callback: @escaping ([String: Any]) -> Void) -> Int {
+        PubSub.subscribe(topic) { result in
+            callback(result.dictionaryRepresentation as [String: Any])
+        }
+    }
+        
+    @objc(publishToTopic:data:) public static func publish(topic: String, data: Any) {
+        guard let data = data as? JSValue else { return }
+        PubSub.publish(topic, message: data)
+    }
+    
+    @objc(unsubscribeFromTopic:subscriptionRef:) public static func unsubscribe(_ topic: String, _ subscriptionRef: Int) {
+        PubSub.unsubscribe(from: topic, subscriptionRef: subscriptionRef)
+    }
+    
+}

--- a/IonicPortals/IonicPortalsTests/PortalsPluginTests.swift
+++ b/IonicPortals/IonicPortalsTests/PortalsPluginTests.swift
@@ -17,17 +17,17 @@ class PortalsPluginTests: XCTestCase {
         let topic = "test:result"
        
         // SUT
-        PubSub.publisher(for: topic)
+        PortalsPubSub.publisher(for: topic)
             .sink { results.append($0) }
             .store(in: &cancellables)
         
-        PubSub.publish(topic, message: 1)
+        PortalsPubSub.publish(topic, message: 1)
         XCTAssertEqual(results.count, 1)
         
-        PubSub.publish(topic, message: 2)
+        PortalsPubSub.publish(topic, message: 2)
         XCTAssertEqual(results.count, 2)
         
-        PubSub.publish(topic, message: 3)
+        PortalsPubSub.publish(topic, message: 3)
         XCTAssertEqual(results.count, 3)
     }
     
@@ -37,15 +37,15 @@ class PortalsPluginTests: XCTestCase {
         let topic = "test:number:data"
         
         // SUT
-        PubSub.publisher(for: topic)
+        PortalsPubSub.publisher(for: topic)
             .data()
             .compactMap { $0 }
             .sink { results.append($0) }
             .store(in: &cancellables)
         
-        PubSub.publish(topic, message: 1)
-        PubSub.publish(topic, message: 2)
-        PubSub.publish(topic, message: 3)
+        PortalsPubSub.publish(topic, message: 1)
+        PortalsPubSub.publish(topic, message: 2)
+        PortalsPubSub.publish(topic, message: 3)
         
         XCTAssertEqual(results.count, 3)
     }
@@ -56,18 +56,18 @@ class PortalsPluginTests: XCTestCase {
         let topic = "test:number:dataAs"
         
         // SUT
-        PubSub.publisher(for: topic)
+        PortalsPubSub.publisher(for: topic)
             .data(as: Int.self)
             .sink { results.append($0) }
             .store(in: &cancellables)
         
-        PubSub.publish(topic, message: 1)
+        PortalsPubSub.publish(topic, message: 1)
         XCTAssertEqual(results, [1])
         
-        PubSub.publish(topic, message: 2)
+        PortalsPubSub.publish(topic, message: 2)
         XCTAssertEqual(results, [1, 2])
         
-        PubSub.publish(topic, message: 3)
+        PortalsPubSub.publish(topic, message: 3)
         XCTAssertEqual(results, [1, 2, 3])
     }
     
@@ -77,18 +77,18 @@ class PortalsPluginTests: XCTestCase {
         let topic = "test:number:dataAs"
         
         // SUT
-        PubSub.publisher(for: topic)
+        PortalsPubSub.publisher(for: topic)
             .data(as: Int.self)
             .sink { results.append($0) }
             .store(in: &cancellables)
         
-        PubSub.publish(topic, message: "hello")
+        PortalsPubSub.publish(topic, message: "hello")
         XCTAssertEqual(results, [nil])
         
-        PubSub.publish(topic, message: 59.03)
+        PortalsPubSub.publish(topic, message: 59.03)
         XCTAssertEqual(results, [nil, nil])
         
-        PubSub.publish(topic, message: true)
+        PortalsPubSub.publish(topic, message: true)
         XCTAssertEqual(results, [nil, nil, nil])
     }
     
@@ -98,18 +98,18 @@ class PortalsPluginTests: XCTestCase {
         let topic = "test:number:dataAs"
         
         // SUT
-        PubSub.publisher(for: topic)
+        PortalsPubSub.publisher(for: topic)
             .data(as: Int.self)
             .sink { results.append($0) }
             .store(in: &cancellables)
         
-        PubSub.publish(topic, message: 1)
+        PortalsPubSub.publish(topic, message: 1)
         XCTAssertEqual(results, [1])
         
-        PubSub.publish(topic, message: 59.03)
+        PortalsPubSub.publish(topic, message: 59.03)
         XCTAssertEqual(results, [1, nil])
         
-        PubSub.publish(topic, message: true)
+        PortalsPubSub.publish(topic, message: true)
         XCTAssertEqual(results, [1, nil, nil])
     }
     
@@ -119,13 +119,13 @@ class PortalsPluginTests: XCTestCase {
         let topic = "test:number:tryDataAs:success"
         
         // SUT
-        PubSub.publisher(for: topic)
+        PortalsPubSub.publisher(for: topic)
             .tryData(as: Int.self)
             .assertNoFailure()
             .sink { results.append($0) }
             .store(in: &cancellables)
        
-        PubSub.publish(topic, message: 1)
+        PortalsPubSub.publish(topic, message: 1)
         
         XCTAssertEqual(results, [1])
     }
@@ -137,7 +137,7 @@ class PortalsPluginTests: XCTestCase {
         let topic = "test:number:tryDataAs:failure"
         
         // SUT
-        PubSub.publisher(for: topic)
+        PortalsPubSub.publisher(for: topic)
             .tryData(as: Int.self)
             .catch { error in
                 Just(-1)
@@ -148,7 +148,7 @@ class PortalsPluginTests: XCTestCase {
             )
             .store(in: &cancellables)
         
-        PubSub.publish(topic, message: "hello")
+        PortalsPubSub.publish(topic, message: "hello")
         
         XCTAssertEqual(results, [-1])
         XCTAssertTrue(completed)
@@ -172,14 +172,14 @@ class PortalsPluginTests: XCTestCase {
         )
         
         // SUT
-        PubSub.publisher(for: topic)
+        PortalsPubSub.publisher(for: topic)
             .decodeData(MagicTheGatheringCard.self, decoder: JSONDecoder())
             .assertNoFailure()
             .sink { results.append($0) }
             .store(in: &cancellables)
         
         let jsObject = try JSONEncoder().encodeJSObject(card)
-        PubSub.publish(topic, message: jsObject)
+        PortalsPubSub.publish(topic, message: jsObject)
         
         XCTAssertEqual(results, [card])
     }
@@ -193,7 +193,7 @@ class PortalsPluginTests: XCTestCase {
         let emptyCard = MagicTheGatheringCard(name: "", manaCost: "", convertedManaCost: 0)
         
         // SUT
-        PubSub.publisher(for: topic)
+        PortalsPubSub.publisher(for: topic)
             .decodeData(MagicTheGatheringCard.self, decoder: JSONDecoder())
             .replaceError(with: emptyCard)
             .sink(
@@ -202,7 +202,7 @@ class PortalsPluginTests: XCTestCase {
             )
             .store(in: &cancellables)
         
-        PubSub.publish(topic, message: 99.82)
+        PortalsPubSub.publish(topic, message: 99.82)
         
         XCTAssertEqual(results, [emptyCard])
         XCTAssertTrue(completed)
@@ -211,7 +211,7 @@ class PortalsPluginTests: XCTestCase {
     #if compiler(>=5.6)
     func test_asyncSubscribe__when_values_are_published__they_are_able_to_be_manipulated_with_async_sequence_apis() async {
         let sut = Task {
-            await PubSub.subscribe("test:asyncstream")
+            await PortalsPubSub.subscribe("test:asyncstream")
                 .map { $0.data }
                 .prefix(2)
                 .first { _ in true }
@@ -223,8 +223,8 @@ class PortalsPluginTests: XCTestCase {
             // subscribers and publishers will be racing at the level of nanoseconds
             // to actually register and publish.
             try await Task.sleep(nanoseconds: 1)
-            PubSub.publish("test:asyncstream", message: 1)
-            PubSub.publish("test:asyncstream", message: 2)
+            PortalsPubSub.publish("test:asyncstream", message: 1)
+            PortalsPubSub.publish("test:asyncstream", message: 2)
         }
         
         guard let firstValue = await sut.value as? Int else {

--- a/IonicPortals/IonicPortalsTests/PortalsPluginTests.swift
+++ b/IonicPortals/IonicPortalsTests/PortalsPluginTests.swift
@@ -17,17 +17,17 @@ class PortalsPluginTests: XCTestCase {
         let topic = "test:result"
        
         // SUT
-        PortalsPlugin.publisher(for: topic)
+        PubSub.publisher(for: topic)
             .sink { results.append($0) }
             .store(in: &cancellables)
         
-        PortalsPlugin.publish(topic, 1)
+        PubSub.publish(topic, message: 1)
         XCTAssertEqual(results.count, 1)
         
-        PortalsPlugin.publish(topic, 2)
+        PubSub.publish(topic, message: 2)
         XCTAssertEqual(results.count, 2)
         
-        PortalsPlugin.publish(topic, 3)
+        PubSub.publish(topic, message: 3)
         XCTAssertEqual(results.count, 3)
     }
     
@@ -37,14 +37,15 @@ class PortalsPluginTests: XCTestCase {
         let topic = "test:number:data"
         
         // SUT
-        PortalsPlugin.publisher(for: topic)
+        PubSub.publisher(for: topic)
             .data()
+            .compactMap { $0 }
             .sink { results.append($0) }
             .store(in: &cancellables)
         
-        PortalsPlugin.publish(topic, 1)
-        PortalsPlugin.publish(topic, 2)
-        PortalsPlugin.publish(topic, 3)
+        PubSub.publish(topic, message: 1)
+        PubSub.publish(topic, message: 2)
+        PubSub.publish(topic, message: 3)
         
         XCTAssertEqual(results.count, 3)
     }
@@ -55,18 +56,18 @@ class PortalsPluginTests: XCTestCase {
         let topic = "test:number:dataAs"
         
         // SUT
-        PortalsPlugin.publisher(for: topic)
+        PubSub.publisher(for: topic)
             .data(as: Int.self)
             .sink { results.append($0) }
             .store(in: &cancellables)
         
-        PortalsPlugin.publish(topic, 1)
+        PubSub.publish(topic, message: 1)
         XCTAssertEqual(results, [1])
         
-        PortalsPlugin.publish(topic, 2)
+        PubSub.publish(topic, message: 2)
         XCTAssertEqual(results, [1, 2])
         
-        PortalsPlugin.publish(topic, 3)
+        PubSub.publish(topic, message: 3)
         XCTAssertEqual(results, [1, 2, 3])
     }
     
@@ -76,18 +77,18 @@ class PortalsPluginTests: XCTestCase {
         let topic = "test:number:dataAs"
         
         // SUT
-        PortalsPlugin.publisher(for: topic)
+        PubSub.publisher(for: topic)
             .data(as: Int.self)
             .sink { results.append($0) }
             .store(in: &cancellables)
         
-        PortalsPlugin.publish(topic, "hello")
+        PubSub.publish(topic, message: "hello")
         XCTAssertEqual(results, [nil])
         
-        PortalsPlugin.publish(topic, 59.03)
+        PubSub.publish(topic, message: 59.03)
         XCTAssertEqual(results, [nil, nil])
         
-        PortalsPlugin.publish(topic, true)
+        PubSub.publish(topic, message: true)
         XCTAssertEqual(results, [nil, nil, nil])
     }
     
@@ -97,18 +98,18 @@ class PortalsPluginTests: XCTestCase {
         let topic = "test:number:dataAs"
         
         // SUT
-        PortalsPlugin.publisher(for: topic)
+        PubSub.publisher(for: topic)
             .data(as: Int.self)
             .sink { results.append($0) }
             .store(in: &cancellables)
         
-        PortalsPlugin.publish(topic, 1)
+        PubSub.publish(topic, message: 1)
         XCTAssertEqual(results, [1])
         
-        PortalsPlugin.publish(topic, 59.03)
+        PubSub.publish(topic, message: 59.03)
         XCTAssertEqual(results, [1, nil])
         
-        PortalsPlugin.publish(topic, true)
+        PubSub.publish(topic, message: true)
         XCTAssertEqual(results, [1, nil, nil])
     }
     
@@ -118,13 +119,13 @@ class PortalsPluginTests: XCTestCase {
         let topic = "test:number:tryDataAs:success"
         
         // SUT
-        PortalsPlugin.publisher(for: topic)
+        PubSub.publisher(for: topic)
             .tryData(as: Int.self)
             .assertNoFailure()
             .sink { results.append($0) }
             .store(in: &cancellables)
        
-        PortalsPlugin.publish(topic, 1)
+        PubSub.publish(topic, message: 1)
         
         XCTAssertEqual(results, [1])
     }
@@ -136,7 +137,7 @@ class PortalsPluginTests: XCTestCase {
         let topic = "test:number:tryDataAs:failure"
         
         // SUT
-        PortalsPlugin.publisher(for: topic)
+        PubSub.publisher(for: topic)
             .tryData(as: Int.self)
             .catch { error in
                 Just(-1)
@@ -147,7 +148,7 @@ class PortalsPluginTests: XCTestCase {
             )
             .store(in: &cancellables)
         
-        PortalsPlugin.publish(topic, "hello")
+        PubSub.publish(topic, message: "hello")
         
         XCTAssertEqual(results, [-1])
         XCTAssertTrue(completed)
@@ -171,14 +172,14 @@ class PortalsPluginTests: XCTestCase {
         )
         
         // SUT
-        PortalsPlugin.publisher(for: topic)
+        PubSub.publisher(for: topic)
             .decodeData(MagicTheGatheringCard.self, decoder: JSONDecoder())
             .assertNoFailure()
             .sink { results.append($0) }
             .store(in: &cancellables)
         
         let jsObject = try JSONEncoder().encodeJSObject(card)
-        PortalsPlugin.publish(topic, jsObject)
+        PubSub.publish(topic, message: jsObject)
         
         XCTAssertEqual(results, [card])
     }
@@ -192,7 +193,7 @@ class PortalsPluginTests: XCTestCase {
         let emptyCard = MagicTheGatheringCard(name: "", manaCost: "", convertedManaCost: 0)
         
         // SUT
-        PortalsPlugin.publisher(for: topic)
+        PubSub.publisher(for: topic)
             .decodeData(MagicTheGatheringCard.self, decoder: JSONDecoder())
             .replaceError(with: emptyCard)
             .sink(
@@ -201,7 +202,7 @@ class PortalsPluginTests: XCTestCase {
             )
             .store(in: &cancellables)
         
-        PortalsPlugin.publish(topic, 99.82)
+        PubSub.publish(topic, message: 99.82)
         
         XCTAssertEqual(results, [emptyCard])
         XCTAssertTrue(completed)
@@ -210,7 +211,7 @@ class PortalsPluginTests: XCTestCase {
     #if compiler(>=5.6)
     func test_asyncSubscribe__when_values_are_published__they_are_able_to_be_manipulated_with_async_sequence_apis() async {
         let sut = Task {
-            await PortalsPlugin.subscribe("test:asyncstream")
+            await PubSub.subscribe("test:asyncstream")
                 .map { $0.data }
                 .prefix(2)
                 .first { _ in true }
@@ -222,8 +223,8 @@ class PortalsPluginTests: XCTestCase {
             // subscribers and publishers will be racing at the level of nanoseconds
             // to actually register and publish.
             try await Task.sleep(nanoseconds: 1)
-            PortalsPlugin.publish("test:asyncstream", 1)
-            PortalsPlugin.publish("test:asyncstream", 2)
+            PubSub.publish("test:asyncstream", message: 1)
+            PubSub.publish("test:asyncstream", message: 2)
         }
         
         guard let firstValue = await sut.value as? Int else {


### PR DESCRIPTION
The goal of this PR is to make Objective-C compatibility first class while also being able to provide the best Swift API we can. This required some separations and a little boilerplate, but it allows us to keep the types that aren't expressible in Objective-C. This pushes the compromises to the interop boundary through intermediary classes made specifically to be used in the Objective-C runtime instead of making the experience for Swift developers compromised. This allowed us to make `Portal` a struct. It being a class actually could have led to some interesting issues. Consider the following:
```swift
let portal = Portal(name: "helpapp", initialContext: ["shouldShowIntroScreen": false ])
PortalManager.add(portal)

var portal = PortalManager.getPortal(named: "helpapp")
if someCondition {
  portal.initialContext = ["shouldShowIntroScreen": true]
}

addSubview(PortalUIView(portal: portal))
```

With `Portal` as a class, `initialContext` will now always be `true` for the `"shouldShowIntroScreen"` key for any part of the application that uses that `Portal` as long as the application is running. That could be a feature or bug, but at least with a struct it requires the developer to be explicit about their intention with `initialContext` instead of relying on the implicit behavior of reference types.

This PR supersedes #15 and should provide everything @NathanWalker would need to be successful with his NativeScript project.