### PR TITLE
API Alignment

### DIFF
--- a/IonicPortals/IonicPortals/PortalsPlugin+SwiftConcurrency.swift
+++ b/IonicPortals/IonicPortals/PortalsPlugin+SwiftConcurrency.swift
@@ -12,7 +12,7 @@ extension PortalsPubSub {
     /// Subscribe to a topic and receive the events in an `AsyncStream`
     /// - Parameter topic: The topic to subscribe to
     /// - Returns: An AsyncStream emitting ``SubscriptionResult``
-    public static func subscribe(_ topic: String) -> AsyncStream<SubscriptionResult> {
+    public static func subscribe(to topic: String) -> AsyncStream<SubscriptionResult> {
         AsyncStream { continuation in
             let ref = PortalsPubSub.subscribe(topic) { result in
                 continuation.yield(result)

--- a/IonicPortals/IonicPortals/PortalsPlugin.swift
+++ b/IonicPortals/IonicPortals/PortalsPlugin.swift
@@ -10,7 +10,7 @@ internal class Plugin: CAPPlugin {
         }
         
         let data = call.getValue("data")
-        PortalsPubSub.publish(topic, message: data)
+        PortalsPubSub.publish(data, to: topic)
         call.resolve()
     }
     

--- a/IonicPortals/IonicPortals/PortalsPubSub.swift
+++ b/IonicPortals/IonicPortals/PortalsPubSub.swift
@@ -51,9 +51,9 @@ public enum PortalsPubSub {
     
     /// Publish event to all listeners of a topic
     /// - Parameters:
+    ///   - message: The data to deliver to all subscribers. Must be a valid JSON data type. Defaults to nil.
     ///   - topic: The topic to publish to
-    ///   - data: The data to deliver to all subscribers. Must be a valid JSON data type. Defaults to nil.
-    public static func publish(_ topic: String, message: JSValue? = nil) {
+    public static func publish(_ message: JSValue? = nil, to topic: String) {
         queue.sync {
             if let subscription = subscriptions[topic] {
                 for (ref, listener) in subscription {
@@ -115,12 +115,12 @@ public struct SubscriptionResult {
         
     /// Publish event to all listeners of a topic
     /// - Parameters:
+    ///   - message: The data to deliver to all subscribers. Must be a valid JSON data type or nil.
     ///   - topic: The topic to publish to
-    ///   - data: The data to deliver to all subscribers. Must be a valid JSON data type or nil.
-    @objc(publishToTopic:data:) public static func publish(topic: String, data: Any?) {
-        guard let data = data else { return PortalsPubSub.publish(topic) }
+    @objc(publishMessage:toTopic:) public static func publish(message: Any?, topic: String) {
+        guard let data = message else { return PortalsPubSub.publish(to: topic) }
         guard let value = coerceToJsValue(data) else { return print("\(data) is not a valid JSON type...not publishing") }
-        PortalsPubSub.publish(topic, message: value)
+        PortalsPubSub.publish(value, to: topic)
     }
     
     /// Stop receiving events. This must be called if subscribing occured through ``subscribe(topic:callback:)`` to prevent a closure from being executed indefinitely.

--- a/IonicPortals/IonicPortalsTests/IonicPortalsObjcTests.m
+++ b/IonicPortals/IonicPortalsTests/IonicPortalsObjcTests.m
@@ -23,7 +23,7 @@
         [expectation fulfill];
     }];
     
-    [IONPortalsPubSub publishToTopic:@"test" data:@YES];
+    [IONPortalsPubSub publishMessage:@YES toTopic:@"test"];
     
     [self waitForExpectations:@[expectation] timeout:1.0];
     [IONPortalsPubSub unsubscribeFromTopic:@"test" subscriptionRef:subRef];
@@ -38,7 +38,7 @@
     }];
     
     NSError *nonJsonCompatible = [[NSError alloc] initWithDomain:NSCocoaErrorDomain code:1 userInfo:nil];
-    [IONPortalsPubSub publishToTopic:@"test" data:nonJsonCompatible];
+    [IONPortalsPubSub publishMessage:nonJsonCompatible toTopic:@"test"];
     
     [self waitForExpectations:@[expectation] timeout:1.0];
     [IONPortalsPubSub unsubscribeFromTopic:@"test" subscriptionRef:subRef];
@@ -65,7 +65,7 @@
         [expectation fulfill];
     }];
     
-    [IONPortalsPubSub publishToTopic:@"test" data:aDict];
+    [IONPortalsPubSub publishMessage:aDict toTopic:@"test"];
     
     [self waitForExpectations:@[expectation] timeout:1.0];
     [IONPortalsPubSub unsubscribeFromTopic:@"test" subscriptionRef:subRef];
@@ -103,7 +103,7 @@
         [expectation fulfill];
     }];
     
-    [IONPortalsPubSub publishToTopic:@"test" data:aDictToPublish];
+    [IONPortalsPubSub publishMessage:aDictToPublish toTopic:@"test"];
     
     [self waitForExpectations:@[expectation] timeout:1.0];
     [IONPortalsPubSub unsubscribeFromTopic:@"test" subscriptionRef:subRef];
@@ -120,7 +120,7 @@
         [expectation fulfill];
     }];
     
-    [IONPortalsPubSub publishToTopic:@"test" data:anArray];
+    [IONPortalsPubSub publishMessage:anArray toTopic:@"test"];
     
     [self waitForExpectations:@[expectation] timeout:1.0];
     [IONPortalsPubSub unsubscribeFromTopic:@"test" subscriptionRef:subRef];
@@ -138,7 +138,7 @@
         [expectation fulfill];
     }];
     
-    [IONPortalsPubSub publishToTopic:@"test" data:anArray];
+    [IONPortalsPubSub publishMessage:anArray toTopic:@"test"];
     
     [self waitForExpectations:@[expectation] timeout:1.0];
     [IONPortalsPubSub unsubscribeFromTopic:@"test" subscriptionRef:subRef];

--- a/IonicPortals/IonicPortalsTests/PortalsPluginTests.swift
+++ b/IonicPortals/IonicPortalsTests/PortalsPluginTests.swift
@@ -21,13 +21,13 @@ class PortalsPluginTests: XCTestCase {
             .sink { results.append($0) }
             .store(in: &cancellables)
         
-        PortalsPubSub.publish(topic, message: 1)
+        PortalsPubSub.publish(1, to: topic)
         XCTAssertEqual(results.count, 1)
         
-        PortalsPubSub.publish(topic, message: 2)
+        PortalsPubSub.publish(2, to: topic)
         XCTAssertEqual(results.count, 2)
         
-        PortalsPubSub.publish(topic, message: 3)
+        PortalsPubSub.publish(3, to: topic)
         XCTAssertEqual(results.count, 3)
     }
     
@@ -43,9 +43,9 @@ class PortalsPluginTests: XCTestCase {
             .sink { results.append($0) }
             .store(in: &cancellables)
         
-        PortalsPubSub.publish(topic, message: 1)
-        PortalsPubSub.publish(topic, message: 2)
-        PortalsPubSub.publish(topic, message: 3)
+        PortalsPubSub.publish(1, to: topic)
+        PortalsPubSub.publish(2, to: topic)
+        PortalsPubSub.publish(3, to: topic)
         
         XCTAssertEqual(results.count, 3)
     }
@@ -61,13 +61,13 @@ class PortalsPluginTests: XCTestCase {
             .sink { results.append($0) }
             .store(in: &cancellables)
         
-        PortalsPubSub.publish(topic, message: 1)
+        PortalsPubSub.publish(1, to: topic)
         XCTAssertEqual(results, [1])
         
-        PortalsPubSub.publish(topic, message: 2)
+        PortalsPubSub.publish(2, to: topic)
         XCTAssertEqual(results, [1, 2])
         
-        PortalsPubSub.publish(topic, message: 3)
+        PortalsPubSub.publish(3, to: topic)
         XCTAssertEqual(results, [1, 2, 3])
     }
     
@@ -82,13 +82,13 @@ class PortalsPluginTests: XCTestCase {
             .sink { results.append($0) }
             .store(in: &cancellables)
         
-        PortalsPubSub.publish(topic, message: "hello")
+        PortalsPubSub.publish("hello", to: topic)
         XCTAssertEqual(results, [nil])
         
-        PortalsPubSub.publish(topic, message: 59.03)
+        PortalsPubSub.publish(59.03, to: topic)
         XCTAssertEqual(results, [nil, nil])
         
-        PortalsPubSub.publish(topic, message: true)
+        PortalsPubSub.publish(true, to: topic)
         XCTAssertEqual(results, [nil, nil, nil])
     }
     
@@ -103,13 +103,13 @@ class PortalsPluginTests: XCTestCase {
             .sink { results.append($0) }
             .store(in: &cancellables)
         
-        PortalsPubSub.publish(topic, message: 1)
+        PortalsPubSub.publish(1, to: topic)
         XCTAssertEqual(results, [1])
         
-        PortalsPubSub.publish(topic, message: 59.03)
+        PortalsPubSub.publish(59.03, to: topic)
         XCTAssertEqual(results, [1, nil])
         
-        PortalsPubSub.publish(topic, message: true)
+        PortalsPubSub.publish(true, to: topic)
         XCTAssertEqual(results, [1, nil, nil])
     }
     
@@ -125,7 +125,7 @@ class PortalsPluginTests: XCTestCase {
             .sink { results.append($0) }
             .store(in: &cancellables)
        
-        PortalsPubSub.publish(topic, message: 1)
+        PortalsPubSub.publish(1, to: topic)
         
         XCTAssertEqual(results, [1])
     }
@@ -148,7 +148,7 @@ class PortalsPluginTests: XCTestCase {
             )
             .store(in: &cancellables)
         
-        PortalsPubSub.publish(topic, message: "hello")
+        PortalsPubSub.publish("hello", to: topic)
         
         XCTAssertEqual(results, [-1])
         XCTAssertTrue(completed)
@@ -179,7 +179,7 @@ class PortalsPluginTests: XCTestCase {
             .store(in: &cancellables)
         
         let jsObject = try JSONEncoder().encodeJSObject(card)
-        PortalsPubSub.publish(topic, message: jsObject)
+        PortalsPubSub.publish(jsObject, to: topic)
         
         XCTAssertEqual(results, [card])
     }
@@ -202,7 +202,7 @@ class PortalsPluginTests: XCTestCase {
             )
             .store(in: &cancellables)
         
-        PortalsPubSub.publish(topic, message: 99.82)
+        PortalsPubSub.publish(99.82, to: topic)
         
         XCTAssertEqual(results, [emptyCard])
         XCTAssertTrue(completed)
@@ -218,7 +218,7 @@ class PortalsPluginTests: XCTestCase {
         
         cancellable = nil
         
-        PortalsPubSub.publish("test:cancellable")
+        PortalsPubSub.publish(to: "test:cancellable")
         wait(for: [expectation], timeout: 1.0)
         
     }
@@ -226,7 +226,7 @@ class PortalsPluginTests: XCTestCase {
     #if compiler(>=5.6)
     func test_asyncSubscribe__when_values_are_published__they_are_able_to_be_manipulated_with_async_sequence_apis() async {
         let sut = Task {
-            await PortalsPubSub.subscribe("test:asyncstream")
+            await PortalsPubSub.subscribe(to: "test:asyncstream")
                 .map { $0.data }
                 .prefix(2)
                 .first { _ in true }
@@ -238,8 +238,8 @@ class PortalsPluginTests: XCTestCase {
             // subscribers and publishers will be racing at the level of nanoseconds
             // to actually register and publish.
             try await Task.sleep(nanoseconds: 1)
-            PortalsPubSub.publish("test:asyncstream", message: 1)
-            PortalsPubSub.publish("test:asyncstream", message: 2)
+            PortalsPubSub.publish(1, to: "test:asyncstream")
+            PortalsPubSub.publish(2, to: "test:asyncstream")
         }
         
         guard let firstValue = await sut.value as? Int else {


### PR DESCRIPTION
breaking: Aligns the API verbiage between Swift and Objc and makes the Swift methods more 'swifty'.