### PR TITLE
Make PortalsPubSub.publish non-blocking

### DIFF
--- a/IonicPortals/IonicPortals.xcodeproj/project.pbxproj
+++ b/IonicPortals/IonicPortals.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		A725DEE627D0266100109471 /* PortalsPlugin+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A725DEE527D0266100109471 /* PortalsPlugin+Combine.swift */; };
 		A725DEEA27D1548C00109471 /* JSONEncoder+JSObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = A725DEE927D1548C00109471 /* JSONEncoder+JSObject.swift */; };
 		A725DEEC27D1553D00109471 /* JSONDecoder+JSObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = A725DEEB27D1553D00109471 /* JSONDecoder+JSObject.swift */; };
+		A72BF93D28346CC400180713 /* Publisher+TestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A72BF93C28346CC400180713 /* Publisher+TestSupport.swift */; };
 		A73E0FA2282DC2F500AE7C54 /* PortalsPubSub.swift in Sources */ = {isa = PBXBuildFile; fileRef = A73E0FA1282DC2F500AE7C54 /* PortalsPubSub.swift */; };
 		A73E0FFA282F9BD500AE7C54 /* IonicPortalsObjcTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A73E0FF1282F74F700AE7C54 /* IonicPortalsObjcTests.m */; };
 		A73E0FFC2830842C00AE7C54 /* IONPortalsPubSubCoersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A73E0FFB2830842C00AE7C54 /* IONPortalsPubSubCoersionTests.swift */; };
@@ -57,6 +58,7 @@
 		A725DEE527D0266100109471 /* PortalsPlugin+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PortalsPlugin+Combine.swift"; sourceTree = "<group>"; };
 		A725DEE927D1548C00109471 /* JSONEncoder+JSObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSONEncoder+JSObject.swift"; sourceTree = "<group>"; };
 		A725DEEB27D1553D00109471 /* JSONDecoder+JSObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSONDecoder+JSObject.swift"; sourceTree = "<group>"; };
+		A72BF93C28346CC400180713 /* Publisher+TestSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Publisher+TestSupport.swift"; sourceTree = "<group>"; };
 		A73E0F9B282DA5E400AE7C54 /* Pods_IonicPortals.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Pods_IonicPortals.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A73E0F9D282DA5F900AE7C54 /* Pods_IonicPortalsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Pods_IonicPortalsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A73E0FA1282DC2F500AE7C54 /* PortalsPubSub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalsPubSub.swift; sourceTree = "<group>"; };
@@ -181,6 +183,7 @@
 				E985F88E269E2D260031F820 /* PortalsPluginTests.swift */,
 				E985F890269E2D260031F820 /* Info.plist */,
 				A73E0FFB2830842C00AE7C54 /* IONPortalsPubSubCoersionTests.swift */,
+				A72BF93C28346CC400180713 /* Publisher+TestSupport.swift */,
 			);
 			path = IonicPortalsTests;
 			sourceTree = "<group>";
@@ -383,6 +386,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A72BF93D28346CC400180713 /* Publisher+TestSupport.swift in Sources */,
 				A73E0FFC2830842C00AE7C54 /* IONPortalsPubSubCoersionTests.swift in Sources */,
 				A73E0FFA282F9BD500AE7C54 /* IonicPortalsObjcTests.m in Sources */,
 				E985F88F269E2D260031F820 /* PortalsPluginTests.swift in Sources */,

--- a/IonicPortals/IonicPortals/PortalsPubSub.swift
+++ b/IonicPortals/IonicPortals/PortalsPubSub.swift
@@ -11,7 +11,7 @@ import Capacitor
 
 /// An interface that enables marshalling data to and from a ``Portal`` over an event bus
 public enum PortalsPubSub {
-    private static let queue = DispatchQueue(label: "io.ionic.portals.pubsub", attributes: .concurrent)
+    private static let queue = DispatchQueue(label: "io.ionic.portals.pubsub")
     
     private static var subscriptions: [String: [Int: (SubscriptionResult) -> Void]] = [:]
     private static var subscriptionRef = 0
@@ -54,7 +54,7 @@ public enum PortalsPubSub {
     ///   - message: The data to deliver to all subscribers. Must be a valid JSON data type. Defaults to nil.
     ///   - topic: The topic to publish to
     public static func publish(_ message: JSValue? = nil, to topic: String) {
-        queue.sync {
+        queue.async {
             if let subscription = subscriptions[topic] {
                 for (ref, listener) in subscription {
                     let result = SubscriptionResult(topic: topic, data: message, subscriptionRef: ref)
@@ -69,7 +69,7 @@ public enum PortalsPubSub {
     ///   - topic: The topic to unsubscribe from
     ///   - subscriptionRef: The subscriptionRef provided during subscription
     public static func unsubscribe(from topic: String, subscriptionRef: Int) {
-        queue.async(flags: .barrier) {
+        queue.async {
             if var subscription = subscriptions[topic] {
                 subscription[subscriptionRef] = nil
                 subscriptions[topic] = subscription

--- a/IonicPortals/IonicPortalsTests/IonicPortalsObjcTests.m
+++ b/IonicPortals/IonicPortalsTests/IonicPortalsObjcTests.m
@@ -60,7 +60,6 @@
     
     NSInteger subRef = [IONPortalsPubSub subscribeToTopic:@"test" callback:^(NSDictionary<NSString *,id> * _Nonnull dict) {
         NSDictionary *publishedDict = dict[@"data"];
-        NSLog( @"%@", dict );
         XCTAssertTrue([publishedDict isEqualToDictionary:aDict]);
         [expectation fulfill];
     }];

--- a/IonicPortals/IonicPortalsTests/Publisher+TestSupport.swift
+++ b/IonicPortals/IonicPortalsTests/Publisher+TestSupport.swift
@@ -1,0 +1,129 @@
+//
+//  Publisher+TestSupport.swift
+//  IonicPortalsTests
+//
+//  Created by Steven Sherry on 5/17/22.
+//
+
+import Combine
+import XCTest
+
+extension Publisher {
+    func expectOutput(
+        toBe values: [Output],
+        expectCompletion: Bool = false,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) -> (AnyCancellable, XCTestExpectation) where Output: Equatable {
+        let publisher: AnyPublisher<[Output], Failure>
+        
+        if expectCompletion {
+            publisher = collect(values.count)
+                .eraseToAnyPublisher()
+        } else {
+            publisher = prefix(values.count)
+                .collect(values.count)
+                .eraseToAnyPublisher()
+        }
+        
+        let expectation = XCTestExpectation(description: "Publisher test")
+        
+        let cancellable = publisher.sink(
+            receiveCompletion: { completion in
+                switch completion {
+                case .finished:
+                    if expectCompletion {
+                        expectation.fulfill()
+                    }
+                case .failure:
+                    XCTFail("Unexpected failure", file: file, line: line)
+                }
+            },
+            receiveValue: { outputs in
+                XCTAssertEqual(values, outputs, file: file, line: line)
+                if !expectCompletion {
+                    expectation.fulfill()
+                }
+            }
+        )
+        
+        return (cancellable, expectation)
+    }
+    
+    func expectOutput(
+        toBe value: Output,
+        expectCompletion: Bool = false,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) -> (AnyCancellable, XCTestExpectation) where Output: Equatable {
+        expectOutput(toBe: [value], expectCompletion: expectCompletion, file: file, line: line)
+    }
+    
+    func assertOutputs(
+        _ predicates: [(Output) -> Bool],
+        expectCompletion: Bool = false,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) -> (AnyCancellable, XCTestExpectation) {
+        let publisher: AnyPublisher<[Output], Failure>
+        
+        if expectCompletion {
+            publisher = collect(predicates.count)
+                .eraseToAnyPublisher()
+        } else {
+            publisher = prefix(predicates.count)
+                .collect(predicates.count)
+                .eraseToAnyPublisher()
+        }
+        
+        let expectation = XCTestExpectation(description: "Publisher test")
+        
+        let cancellable = publisher.sink(
+            receiveCompletion: { completion in
+                switch completion {
+                case .finished:
+                    if expectCompletion {
+                        expectation.fulfill()
+                    }
+                case .failure:
+                    XCTFail("Unexpected failure", file: file, line: line)
+                }
+            },
+            receiveValue: { outputs in
+                for (index, (predicate, output)) in Swift.zip(predicates, outputs).enumerated() {
+                    XCTAssertTrue(predicate(output), "Issue asserting on element number \(index) - \(output)", file: file, line: line)
+                }
+                
+                if !expectCompletion {
+                    expectation.fulfill()
+                }
+            }
+        )
+        
+        return (cancellable, expectation)
+    }
+    
+    func expectError(file: StaticString = #file, line: UInt = #line) -> (AnyCancellable, XCTestExpectation) {
+        let expectation = XCTestExpectation(description: "Publisher test")
+        
+        let cancellable = sink(
+            receiveCompletion: { completion in
+                switch completion {
+                case .finished:
+                    XCTFail("Should have errored", file: file, line: line)
+                case .failure:
+                    expectation.fulfill()
+                }
+            },
+            receiveValue: { _ in }
+        )
+        
+        return (cancellable, expectation)
+    }
+}
+
+extension XCTestCase {
+    func wait(for combineExpectation: (AnyCancellable, XCTestExpectation), timeout: TimeInterval) {
+        self.wait(for: [combineExpectation.1], timeout: timeout)
+    }
+}


### PR DESCRIPTION
fix: The publish function was blocking callers who publish until all subscribers were published to. In practice this is unlikely to be noticeable, but if there are many subscribers it could potentially block the caller for an inordinate amount of time.

chore: Add test helpers for Combine and update tests to use them.

chore: Remove NSLog from objective-c tests.