### PR TITLE
Make Portals `Bundle` agnostic

### DIFF
--- a/Sources/IonicPortals/Portal.swift
+++ b/Sources/IonicPortals/Portal.swift
@@ -107,7 +107,7 @@ extension IONPortal {
     /// Creates an instance of ``IONPortal``
     /// - Parameters:
     ///   - name: The name of the portal, must be unique.
-    ///   - startDir: The starting directory of the ``Portal`` relative to the root of the `Bundle`.
+    ///   - startDir: The starting directory of the ``Portal`` relative to the root of ``bundle``.
     ///     If `nil`, the portal name is used as the starting directory.
     ///   - initialContext: Any initial state rqeuired by the web application. Defaults to `[:]`.
     @objc public convenience init(name: String, startDir: String?, initialContext: [String: Any]?) {
@@ -124,7 +124,7 @@ extension IONPortal {
     /// Creates an instance of ``IONPortal``
     /// - Parameters:
     ///   - name: The name of the portal, must be unique.
-    ///   - startDir: The starting directory of the ``Portal`` relative to the root of the `Bundle`.
+    ///   - startDir: The starting directory of the ``Portal`` relative to the root of the ``bundle``.
     ///     If `nil`, the portal name is used as the starting directory.
     ///   - bundle: The `Bundle` that contains the web application.
     ///   - initialContext: Any initial state rqeuired by the web application. Defaults to `[:]`.

--- a/Sources/IonicPortals/Portal.swift
+++ b/Sources/IonicPortals/Portal.swift
@@ -8,8 +8,11 @@ public struct Portal {
     /// The name of the portal
     public let name: String
     
-    /// The root directory of the ``Portal`` relative to root of the `Bundle`
+    /// The root directory of the ``Portal`` web application relative to the root of ``bundle``
     public let startDir: String
+    
+    /// The `Bundle` that contains the web application.
+    public var bundle: Bundle
     
     /// Any initial state required by the web application
     public var initialContext: JSObject
@@ -25,14 +28,16 @@ public struct Portal {
     /// Creates an instance of ``Portal``
     /// - Parameters:
     ///   - name: The name of the portal, must be unique.
-    ///   - startDir: The starting directory of the ``Portal`` relative to the root of the ``Bundle``.
+    ///   - startDir: The starting directory of the ``Portal`` relative to the root of ``bundle``.
     ///     If `nil`, the portal name is used as the starting directory. Defaults to `nil`.
+    ///   - bundle: The `Bundle` that contains the web application. Defaults to `Bundle.main`.
     ///   - initialContext: Any initial state rqeuired by the web application. Defaults to `[:]`.
     ///   - liveUpdateConfig: The `LiveUpdate` configuration used to determine to location of updated application assets. Defaults to `nil`.
-    public init(name: String, startDir: String? = nil, initialContext: JSObject = [:], liveUpdateConfig: LiveUpdate? = nil) {
+    public init(name: String, startDir: String? = nil, bundle: Bundle = .main, initialContext: JSObject = [:], liveUpdateConfig: LiveUpdate? = nil) {
         self.name = name
         self.startDir = startDir ?? name
         self.initialContext = initialContext
+        self.bundle = bundle
         self.liveUpdateConfig = liveUpdateConfig
         if let liveUpdateConfig = liveUpdateConfig {
             try? LiveUpdateManager.shared.add(liveUpdateConfig)
@@ -51,14 +56,20 @@ extension Portal: ExpressibleByStringLiteral {
     }
 }
 
-/// The objective-c representation of ``Portal``. If using Swift, using ``Portal`` is preferred.
+/// The Objective-C representation of ``Portal``. If using Swift, using ``Portal`` is preferred.
 @objc public class IONPortal: NSObject {
     internal var portal: Portal
     
     /// The name of the portal
     @objc public var name: String { portal.name }
     
-    /// The root directory of the ``Portal`` relative to root of the `Bundle`
+    /// The `Bundle` that contains the web application.
+    @objc public var bundle: Bundle {
+        get { portal.bundle }
+        set { portal.bundle = newValue }
+    }
+    
+    /// The root directory of the ``IONPortal`` relative to root of the `Bundle`
     @objc public var startDir: String { portal.startDir }
     
     /// Any initial state required by the web application.
@@ -93,10 +104,10 @@ extension Portal: ExpressibleByStringLiteral {
 }
 
 extension IONPortal {
-    /// Creates an instance of ``Portal``
+    /// Creates an instance of ``IONPortal``
     /// - Parameters:
     ///   - name: The name of the portal, must be unique.
-    ///   - startDir: The starting directory of the ``Portal`` relative to the root of the ``Bundle``.
+    ///   - startDir: The starting directory of the ``Portal`` relative to the root of the `Bundle`.
     ///     If `nil`, the portal name is used as the starting directory.
     ///   - initialContext: Any initial state rqeuired by the web application. Defaults to `[:]`.
     @objc public convenience init(name: String, startDir: String?, initialContext: [String: Any]?) {
@@ -108,5 +119,17 @@ extension IONPortal {
         )
         
         self.init(portal: portal)
+    }
+    
+    /// Creates an instance of ``IONPortal``
+    /// - Parameters:
+    ///   - name: The name of the portal, must be unique.
+    ///   - startDir: The starting directory of the ``Portal`` relative to the root of the `Bundle`.
+    ///     If `nil`, the portal name is used as the starting directory.
+    ///   - bundle: The `Bundle` that contains the web application.
+    ///   - initialContext: Any initial state rqeuired by the web application. Defaults to `[:]`.
+    @objc public convenience init(name: String, startDir: String?, bundle: Bundle, initialContext: [String: Any]?) {
+        self.init(name: name, startDir: startDir, initialContext: initialContext)
+        self.bundle = bundle
     }
 }

--- a/Sources/IonicPortals/PortalUIView.swift
+++ b/Sources/IonicPortals/PortalUIView.swift
@@ -85,15 +85,15 @@ public class PortalUIView: UIView {
         }
         
         override func instanceDescriptor() -> InstanceDescriptor {
-            let bundleURL = Bundle.main.url(forResource: self.portal.startDir, withExtension: nil)
+            let bundleURL = portal.bundle.url(forResource: portal.startDir, withExtension: nil)
             
-            guard let path = self.liveUpdatePath ?? bundleURL else {
+            guard let path = liveUpdatePath ?? bundleURL else {
                 // DCG this should throw or something else
                 return InstanceDescriptor()
             }
             
-            let capConfigUrl = Bundle.main.url(forResource: "capacitor.config", withExtension: "json", subdirectory: portal.startDir)
-            let cordovaConfigUrl = Bundle.main.url(forResource: "config", withExtension: "xml", subdirectory: portal.startDir)
+            let capConfigUrl = portal.bundle.url(forResource: "capacitor.config", withExtension: "json", subdirectory: portal.startDir)
+            let cordovaConfigUrl = portal.bundle.url(forResource: "config", withExtension: "xml", subdirectory: portal.startDir)
             
             let descriptor = InstanceDescriptor(at: path, configuration: capConfigUrl, cordovaConfiguration: cordovaConfigUrl)
             
@@ -101,9 +101,11 @@ public class PortalUIView: UIView {
         }
         
         override func loadInitialContext(_ userContentViewController: WKUserContentController) {
-            guard portal.initialContext.isNotEmpty, let jsonData = try? JSONSerialization.data(withJSONObject: portal.initialContext) else { return }
+            guard portal.initialContext.isNotEmpty,
+                  let jsonData = try? JSONSerialization.data(withJSONObject: portal.initialContext),
+                  let jsonString = String(data: jsonData, encoding: .utf8)
+            else { return }
                 
-            let jsonString = String(data: jsonData, encoding: .utf8) ?? ""
             let portalInitialContext = #"{ "name": "\#(portal.name)", "value": \#(jsonString) }"#
             let scriptSource = "window.portalInitialContext = " + portalInitialContext
             

--- a/Sources/IonicPortals/PortalsPlugin+Combine.swift
+++ b/Sources/IonicPortals/PortalsPlugin+Combine.swift
@@ -56,7 +56,7 @@ extension PortalsPubSub {
         }
     }
     
-    /// Subscribes to a topic and publishes a `SubscriptionResult` downstream
+    /// Subscribes to a topic and publishes a ``SubscriptionResult`` downstream
     /// - Parameter topic: The topic to subscribe to
     /// - Returns: A ``Publisher``
     public static func publisher(for topic: String) -> Publisher {

--- a/Sources/IonicPortals/PortalsPubSub.swift
+++ b/Sources/IonicPortals/PortalsPubSub.swift
@@ -85,7 +85,7 @@ public struct SubscriptionResult {
     public var topic: String
     /// The value emitted
     public var data: JSValue?
-    /// The reference to the subscription. Used for calling ``PubSub/unsubscribe(from:subscriptionRef:)``
+    /// The reference to the subscription. Used for calling ``PortalsPubSub/unsubscribe(from:subscriptionRef:)``
     public var subscriptionRef: Int
     
     var dictionaryRepresentation: [String: JSValue?] {
@@ -97,7 +97,7 @@ public struct SubscriptionResult {
     }
 }
 
-/// An objective-c interface that enables marshalling data to and from a ``Portal`` over an event bus. If using Swift, ``PortalsPubSub`` is the perferred interface.
+/// An Objective-C interface that enables marshalling data to and from a ``Portal`` over an event bus. If using Swift, ``PortalsPubSub`` is the perferred interface.
 @objc public class IONPortalsPubSub: NSObject {
     private override init() { }
     


### PR DESCRIPTION
feat: Add `bundle` variable to `Portal` to enable bundling web assets in frameworks and packages as opposed to forcing them to be bundled in the application target by depending on `Bundle.main`.
chore: Documentation fixes