### PR TITLE
fix: Show UIAlert for registration error when presenting UnregisteredView

### DIFF
--- a/Sources/IonicPortals/PortalUIView.swift
+++ b/Sources/IonicPortals/PortalUIView.swift
@@ -41,7 +41,8 @@ public class PortalUIView: UIView {
             
             addPinnedSubview(webView)
         } else {
-            let _view = Unregistered()
+            let showRegistrationError = PortalsRegistrationManager.shared.registrationState == .error
+            let _view = Unregistered(shouldShowRegistrationError: showRegistrationError)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .edgesIgnoringSafeArea(.all)
                 .background(Color.portalBlue)

--- a/Sources/IonicPortals/PortalsRegistrationManager.swift
+++ b/Sources/IonicPortals/PortalsRegistrationManager.swift
@@ -90,15 +90,7 @@ public class PortalsRegistrationManager: NSObject {
     }
     
     private func registrationError() {
-        print("Error validating key")
-        
-        let alert = UIAlertController(title: nil, message: "Error validating your key for Ionic Portals. Check your key and try again.", preferredStyle: .alert)
-        let okButton = UIAlertAction(title: "OK", style: .default, handler: { action -> Void in alert.dismiss(animated: true) })
-        
-        alert.addAction(okButton)
-        
-        let keyWindow = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
-        keyWindow?.rootViewController = alert
+        print("Error validating your key for Ionic Portals. Check your key and try again.")
     }
     
     private func unregisteredMessage() {

--- a/Sources/IonicPortals/PortalsRegistrationManager.swift
+++ b/Sources/IonicPortals/PortalsRegistrationManager.swift
@@ -4,7 +4,7 @@ import UIKit
 /// Manages the registration lifecycle
 @objc(IONPortalsRegistrationManager)
 public class PortalsRegistrationManager: NSObject {
-    enum RegistrationState {
+    enum RegistrationState: Equatable {
         case unregistered(messageShown: Bool)
         case registered
         case error
@@ -15,7 +15,7 @@ public class PortalsRegistrationManager: NSObject {
     /// The default singleton
     @objc public static let shared = PortalsRegistrationManager()
 
-    private var registrationState: RegistrationState = .unregistered(messageShown: false)
+    internal private(set) var registrationState: RegistrationState = .unregistered(messageShown: false)
 
     /// Whether Portals has been registered.
     /// Will be true when ``register(key:)`` has been called with a valid key.

--- a/Sources/IonicPortals/UnregisteredView.swift
+++ b/Sources/IonicPortals/UnregisteredView.swift
@@ -3,6 +3,12 @@ import UIKit
 import SwiftUI
 
 struct Unregistered: View {
+    @State private var shouldShowRegistrationError: Bool
+    
+    init(shouldShowRegistrationError: Bool) {
+        self.shouldShowRegistrationError = shouldShowRegistrationError
+    }
+    
     var body: some View {
         VStack {
             VStack(spacing: 32) {
@@ -23,6 +29,13 @@ struct Unregistered: View {
                 .foregroundColor(.white)
             }
             .padding()
+            .alert(isPresented: $shouldShowRegistrationError) {
+                Alert(
+                    title: Text("Registration Error"),
+                    message: Text("Error validating your key for Ionic Portals. Check your key and try again."),
+                    dismissButton: Alert.Button.default(Text("OK"))
+                )
+            }
         }
     }
 }
@@ -34,7 +47,7 @@ public class UnregisteredView: UIView {
 struct Unregistered_Previews: PreviewProvider {
     static var previews: some View {
         HStack {
-            Unregistered()
+            Unregistered(shouldShowRegistrationError: true)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.portalBlue)


### PR DESCRIPTION
fix: Don't show a UIAlert for registration error immediately. Replacing the window is not a great practice and attempting to show an alert without having any context of the view is also pretty bad. ~Logging out the error is in line with how android communicates the registration error.~ Android shows the alert whenever the portal is attempted to be rendered. That is also a possible alternative.