### PR TITLE
feat: Add the ability to specify a custom LiveUpdateManager

### DIFF
--- a/IonicPortals.podspec
+++ b/IonicPortals.podspec
@@ -10,6 +10,6 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/ionic-team/ionic-portals-ios.git', :tag => s.version.to_s }
   s.source_files = 'Sources/IonicPortals/*.swift'
   s.dependency 'Capacitor', '~> 3.5'
-  s.dependency 'IonicLiveUpdates', '~> 0.1.0'
+  s.dependency 'IonicLiveUpdates', '~> 0.1.2'
   s.swift_version = '5.4'
 end

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/ionic-team/ionic-live-updates-releases",
         "state": {
           "branch": null,
-          "revision": "86b4676cf6993b5d14def002b3b507caf67cb96c",
-          "version": "0.1.0"
+          "revision": "7bcd492d49c2667eccd22a4971a0e95b635bc117",
+          "version": "0.1.2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm", .upToNextMajor(from: "3.5.1")),
-        .package(url: "https://github.com/ionic-team/ionic-live-updates-releases", .upToNextMinor(from: "0.1.0")),
+        .package(url: "https://github.com/ionic-team/ionic-live-updates-releases", .upToNextMinor(from: "0.1.2")),
     ],
     targets: [
         .target(

--- a/Sources/IonicPortals/Portal.swift
+++ b/Sources/IonicPortals/Portal.swift
@@ -17,11 +17,14 @@ public struct Portal {
     /// Any initial state required by the web application
     public var initialContext: JSObject
     
+    /// The `LiveUpdateManager` responsible for locating the latest source for the web application
+    public var liveUpdateManager: LiveUpdateManager
+
     /// The `LiveUpdate` configuration used to determine the location of updated application assets.
     public var liveUpdateConfig: LiveUpdate? = nil {
         didSet {
             guard let liveUpdateConfig = liveUpdateConfig else { return }
-            try? LiveUpdateManager.shared.add(liveUpdateConfig)
+            try? liveUpdateManager.add(liveUpdateConfig)
         }
     }
     
@@ -32,15 +35,24 @@ public struct Portal {
     ///     If `nil`, the portal name is used as the starting directory. Defaults to `nil`.
     ///   - bundle: The `Bundle` that contains the web application. Defaults to `Bundle.main`.
     ///   - initialContext: Any initial state rqeuired by the web application. Defaults to `[:]`.
+    ///   - liveUpdateManager: The `LiveUpdateManager` responsible for locating the source source for the web application. Defaults to `LiveUpdateManager.shared`.
     ///   - liveUpdateConfig: The `LiveUpdate` configuration used to determine to location of updated application assets. Defaults to `nil`.
-    public init(name: String, startDir: String? = nil, bundle: Bundle = .main, initialContext: JSObject = [:], liveUpdateConfig: LiveUpdate? = nil) {
+    public init(
+        name: String,
+        startDir: String? = nil,
+        bundle: Bundle = .main,
+        initialContext: JSObject = [:],
+        liveUpdateManager: LiveUpdateManager = .shared,
+        liveUpdateConfig: LiveUpdate? = nil
+    ) {
         self.name = name
         self.startDir = startDir ?? name
         self.initialContext = initialContext
         self.bundle = bundle
+        self.liveUpdateManager = liveUpdateManager
         self.liveUpdateConfig = liveUpdateConfig
         if let liveUpdateConfig = liveUpdateConfig {
-            try? LiveUpdateManager.shared.add(liveUpdateConfig)
+            try? liveUpdateManager.add(liveUpdateConfig)
         }
     }
 }

--- a/Sources/IonicPortals/PortalUIView.swift
+++ b/Sources/IonicPortals/PortalUIView.swift
@@ -36,7 +36,7 @@ public class PortalUIView: UIView {
     func initView () {
         if PortalsRegistrationManager.shared.isRegistered {
             if let liveUpdateConfig = portal.liveUpdateConfig {
-                self.liveUpdatePath = try? LiveUpdateManager.shared.latestAppDirectory(for: liveUpdateConfig.appId)
+                self.liveUpdatePath = try? portal.liveUpdateManager.latestAppDirectory(for: liveUpdateConfig.appId)
             }
             
             addPinnedSubview(webView)
@@ -58,7 +58,7 @@ public class PortalUIView: UIView {
         guard
             let liveUpdate = portal.liveUpdateConfig,
             let capViewController = bridge.viewController as? CAPBridgeViewController,
-            let latestAppPath = try? LiveUpdateManager.shared.latestAppDirectory(for: liveUpdate.appId)
+            let latestAppPath = try? portal.liveUpdateManager.latestAppDirectory(for: liveUpdate.appId)
         else { return }
 
         if liveUpdatePath == nil || liveUpdatePath?.path != latestAppPath.path {


### PR DESCRIPTION
This can allow different teams to manage the LiveUpdate lifecycle independently.