### PR TITLE
fix: fix base64url conversion

### DIFF
--- a/Sources/IonicPortals/PortalsRegistrationManager.swift
+++ b/Sources/IonicPortals/PortalsRegistrationManager.swift
@@ -39,9 +39,10 @@ public class PortalsRegistrationManager: NSObject {
             .replacingOccurrences(of: "-", with: "+")
             .replacingOccurrences(of: "_", with: "/")
 
-        let padding = 4 - base64.count % 4
-        guard padding > 0 else { return base64 }
+        let remainder = base64.count % 4
+        guard remainder > 0 else { return base64 }
 
+        let padding = 4 - base64.count % 4
         base64 += String(repeating: "=", count: padding)
         return base64
     }

--- a/Sources/IonicPortals/PortalsRegistrationManager.swift
+++ b/Sources/IonicPortals/PortalsRegistrationManager.swift
@@ -42,7 +42,7 @@ public class PortalsRegistrationManager: NSObject {
         let remainder = base64.count % 4
         guard remainder > 0 else { return base64 }
 
-        let padding = 4 - base64.count % 4
+        let padding = 4 - remainder
         base64 += String(repeating: "=", count: padding)
         return base64
     }

--- a/Sources/IonicPortals/PortalsRegistrationManager.swift
+++ b/Sources/IonicPortals/PortalsRegistrationManager.swift
@@ -38,7 +38,11 @@ public class PortalsRegistrationManager: NSObject {
         var base64 = base64Url
             .replacingOccurrences(of: "-", with: "+")
             .replacingOccurrences(of: "_", with: "/")
-        base64 += String(repeating: "=", count: base64.count % 4)
+        
+        let padding = 4 - base64.count % 4
+        guard padding > 0 else { return base64 }
+        
+        base64 += String(repeating: "=", count: padding)
         return base64
     }
     

--- a/Sources/IonicPortals/PortalsRegistrationManager.swift
+++ b/Sources/IonicPortals/PortalsRegistrationManager.swift
@@ -38,10 +38,10 @@ public class PortalsRegistrationManager: NSObject {
         var base64 = base64Url
             .replacingOccurrences(of: "-", with: "+")
             .replacingOccurrences(of: "_", with: "/")
-        
+
         let padding = 4 - base64.count % 4
         guard padding > 0 else { return base64 }
-        
+
         base64 += String(repeating: "=", count: padding)
         return base64
     }


### PR DESCRIPTION
The existing base64url conversion to base64 is unsound. The current operation as it exists uses the _remainder_ as the padding amount, which means that padding could be potentially over applied. This has not occurred because it appears that our signature of the data has always had a remainder of 2. I assume this is the case because the size of the data we're signing itself is always the same regardless of the key, but if that changes then the current implementation will cause a crash.