### PR TITLE
fix: Don't let capacitor take over as UNNotificationCenterDelegate

### DIFF
--- a/Sources/IonicPortals/PortalUIView.swift
+++ b/Sources/IonicPortals/PortalUIView.swift
@@ -95,7 +95,7 @@ public class PortalUIView: UIView {
             let cordovaConfigUrl = portal.bundle.url(forResource: "config", withExtension: "xml", subdirectory: portal.startDir)
             
             let descriptor = InstanceDescriptor(at: path, configuration: capConfigUrl, cordovaConfiguration: cordovaConfigUrl)
-            
+            descriptor.handleApplicationNotifications = false
             return descriptor
         }
         


### PR DESCRIPTION
Capacitor by default takes over responding to notifications. We should not allow this. If people want to notify their portal of changes from a push notification, they should use PubSub to publish those events as they're received.