### PR TITLE
feat: always have an initialContext

### DIFF
--- a/Sources/IonicPortals/PortalUIView.swift
+++ b/Sources/IonicPortals/PortalUIView.swift
@@ -100,12 +100,16 @@ public class PortalUIView: UIView {
         }
         
         override func loadInitialContext(_ userContentViewController: WKUserContentController) {
-            guard portal.initialContext.isNotEmpty,
-                  let jsonData = try? JSONSerialization.data(withJSONObject: portal.initialContext),
-                  let jsonString = String(data: jsonData, encoding: .utf8)
-            else { return }
+            let portalInitialContext: String
+            
+            if portal.initialContext.isNotEmpty,
+                let jsonData = try? JSONSerialization.data(withJSONObject: portal.initialContext),
+                let jsonString = String(data: jsonData, encoding: .utf8) {
+                portalInitialContext = #"{ "name": "\#(portal.name)", "value": \#(jsonString) }"#
+            } else {
+                portalInitialContext = #"{ "name": "\#(portal.name)" }"#
+            }
                 
-            let portalInitialContext = #"{ "name": "\#(portal.name)", "value": \#(jsonString) }"#
             let scriptSource = "window.portalInitialContext = " + portalInitialContext
             
             let userScript = WKUserScript(


### PR DESCRIPTION
feat: Previously, if no initialContext no was passed to a portal, the web side of the portal would not have access to its name property. This change allows for the portal to have access to its name regardless of there being an initial value passed in or not.