### PR TITLE
fix: Refactor codable support

### DIFF
--- a/Sources/IonicPortals/JSONDecoder+JSObject.swift
+++ b/Sources/IonicPortals/JSONDecoder+JSObject.swift
@@ -9,10 +9,14 @@ import Foundation
 import Capacitor
 
 public extension JSONDecoder {
+    @available(*, deprecated, renamed: "decodeJsObject")
     func decodeJSObject<T: Decodable>(_ type: T.Type, from object: JSObject) throws -> T {
+        try decodeJsObject(type, from: object)
+    }
+
+    func decodeJsObject<T: Decodable>(_ type: T.Type, from object: JSObject) throws -> T {
         let data = try JSONSerialization.data(withJSONObject: object, options: [])
-        let result = try decode(T.self, from: data)
-        return result
+        return try decode(T.self, from: data)
     }
 }
 

--- a/Sources/IonicPortals/JSONEncoder+JSObject.swift
+++ b/Sources/IonicPortals/JSONEncoder+JSObject.swift
@@ -11,11 +11,18 @@ import Combine
 
 
 public extension JSONEncoder {
+    @available(*, deprecated, renamed: "encodeJsObject")
     func encodeJSObject<T: Encodable>(_ value: T) throws -> JSValue {
+        try encodeJsObject(value)
+    }
+
+    func encodeJsObject<T: Encodable>(_ value: T) throws -> JSObject {
         let data = try encode(value)
         let dictionary = try JSONSerialization.jsonObject(with: data, options: []) as? NSDictionary
-       
-        // Any valid Codable type should not fail here. 
+
+        // Any valid Codable type that is keyed should not fail here.
+        // An unkeyed or single value container would have failed in the
+        // JSONSerialization step.
         return JSTypes.coerceDictionaryToJSObject(dictionary)!
     }
 }

--- a/Sources/IonicPortals/PortalsPlugin+Combine.swift
+++ b/Sources/IonicPortals/PortalsPlugin+Combine.swift
@@ -104,7 +104,7 @@ extension PortalsPubSub.Publisher {
     /// - Returns: A publisher emitting the decoded value or a decoding error.
     public func decodeData<T>(_ type: T.Type, decoder: JSONDecoder) -> AnyPublisher<T, Error> where T: Decodable {
         tryData(as: JSObject.self)
-            .tryMap { try decoder.decodeJSObject(T.self, from: $0) }
+            .tryMap { try decoder.decodeJsObject(T.self, from: $0) }
             .eraseToAnyPublisher()
     }
 }

--- a/Tests/IonicPortalsTests/PortalsPluginTests.swift
+++ b/Tests/IonicPortalsTests/PortalsPluginTests.swift
@@ -141,7 +141,7 @@ class PortalsPluginTests: XCTestCase {
             .assertNoFailure()
             .expectOutput(toBe: card)
         
-        let jsObject = try JSONEncoder().encodeJSObject(card)
+        let jsObject = try JSONEncoder().encodeJsObject(card)
         PortalsPubSub.publish(jsObject, to: topic)
         
         wait(for: result, timeout: 1)


### PR DESCRIPTION
fix: Refactor codable support. `encodeJSObject` returned a JSValue, but there is no reason to not return the more concrete JSObject. The current `encodeJSObject` method requires a developer to call `encodeJSObject` and then cast it to a JSObject if it's required (e.g. applying the data to initialContext).