### PR TITLE
feat!: Breaking overhauls the pub/sub system

### DIFF
--- a/Sources/IonicPortals/PortalUIView.swift
+++ b/Sources/IonicPortals/PortalUIView.swift
@@ -81,7 +81,7 @@ public class PortalUIView: UIView {
         
         override func capacitorDidLoad() {
             if case let .manual(plugins) = portal.pluginRegistrationMode {
-                bridge.registerPluginType(Plugin.self)
+                bridge.registerPluginType(PortalsPlugin.self)
 
                 plugins.forEach { plugin in
                     switch plugin {

--- a/Sources/IonicPortals/PortalsPlugin+SwiftConcurrency.swift
+++ b/Sources/IonicPortals/PortalsPlugin+SwiftConcurrency.swift
@@ -14,12 +14,12 @@ extension PortalsPubSub {
     /// - Returns: An AsyncStream emitting ``SubscriptionResult``
     public static func subscribe(to topic: String) -> AsyncStream<SubscriptionResult> {
         AsyncStream { continuation in
-            let ref = PortalsPubSub.subscribe(topic) { result in
+            let cancellable = PortalsPubSub.subscribe(to: topic) { result in
                 continuation.yield(result)
             }
             
-            continuation.onTermination = { @Sendable _ in
-                PortalsPubSub.unsubscribe(from: topic, subscriptionRef: ref)
+            continuation.onTermination = { @Sendable [cancellable] _ in
+                cancellable.cancel()
             }
         }
     }

--- a/Sources/IonicPortals/PortalsPlugin.swift
+++ b/Sources/IonicPortals/PortalsPlugin.swift
@@ -22,7 +22,7 @@ public final class PortalsPlugin: CAPPlugin, CAPBridgedPlugin {
         methods.first { $0.name == methodName }
     }
     
-    private var publishers: [String: AnyCancellable] = [:]
+    private var publishers = ConcurrentDictionary(label: "io.ionic.portalsplugin", dict: [String: AnyCancellable]())
     private var pubsub: PortalsPubSub = .shared
     
     public convenience init(pubsub: PortalsPubSub) {

--- a/Sources/IonicPortals/PortalsPlugin.swift
+++ b/Sources/IonicPortals/PortalsPlugin.swift
@@ -1,26 +1,33 @@
 import Foundation
 import Capacitor
+import Combine
 
 @objc(IONPortalsPlugin)
-internal final class Plugin: CAPPlugin, CAPBridgedPlugin {
-    static func pluginId() -> String {
+public final class PortalsPlugin: CAPPlugin, CAPBridgedPlugin {
+    public static func pluginId() -> String {
         "IONPortalsPlugin"
     }
     
-    static func jsName() -> String {
+    public static func jsName() -> String {
         "Portals"
     }
     
     static let methods: [CAPPluginMethod] = [
-        CAPPluginMethod(name: "publishNative", returnType: CAPPluginReturnPromise),
-        CAPPluginMethod(name: "subscribeNative", returnType: CAPPluginReturnCallback),
-        CAPPluginMethod(name: "unsubscribeNative", returnType: CAPPluginReturnPromise)
+        CAPPluginMethod(name: "publishNative", returnType: CAPPluginReturnPromise)
     ]
     
-    static func pluginMethods() -> [Any] { methods }
+    public static func pluginMethods() -> [Any] { methods }
     
-    static func getMethod(_ methodName: String) -> CAPPluginMethod? {
+    public static func getMethod(_ methodName: String) -> CAPPluginMethod? {
         methods.first { $0.name == methodName }
+    }
+    
+    private var publishers: [String: AnyCancellable] = [:]
+    private var pubsub: PortalsPubSub = .shared
+    
+    public convenience init(pubsub: PortalsPubSub) {
+        self.init()
+        self.pubsub = pubsub
     }
     
     @objc func publishNative(_ call: CAPPluginCall) {
@@ -29,34 +36,19 @@ internal final class Plugin: CAPPlugin, CAPBridgedPlugin {
         }
         
         let data = call.getValue("data")
-        PortalsPubSub.publish(data, to: topic)
+        pubsub.publish(data, to: topic)
         call.resolve()
     }
     
-    @objc func subscribeNative(_ call: CAPPluginCall) {
-        guard let topic = call.getString("topic") else {
-            call.reject("topic not provided")
-            return
-        }
-        call.keepAlive = true
-        
-        let ref = IONPortalsPubSub.subscribe(topic: topic, callback: call.resolve)
-        call.resolve([
-            "topic": topic,
-            "subscriptionRef": ref
-        ])
-    }
-    
-    @objc func unsubscribeNative(_ call: CAPPluginCall) {
-        guard let topic = call.getString("topic") else {
-            call.reject("topic not provided")
-            return
-        }
-        guard let subscriptionRef = call.getInt("subscriptionRef") else {
-            call.reject("subscriptionRef not provided")
-            return
-        }
-        PortalsPubSub.unsubscribe(from: topic, subscriptionRef: subscriptionRef)
-        call.resolve()
+    public override func addEventListener(_ eventName: String, listener: CAPPluginCall) {
+        super.addEventListener(eventName, listener: listener)
+        guard publishers[eventName] == nil else { return }
+        publishers[eventName] = pubsub.publisher(for: eventName)
+            .sink { [weak self] result in
+                self?.notifyListeners(
+                    eventName,
+                    data: result.dictionaryRepresentation as [String: Any]
+                )
+            }
     }
 }

--- a/Sources/IonicPortals/PortalsPubSub.swift
+++ b/Sources/IonicPortals/PortalsPubSub.swift
@@ -9,74 +9,98 @@ import Foundation
 import Combine
 import Capacitor
 
-/// An interface that enables marshalling data to and from a ``Portal`` over an event bus
-public enum PortalsPubSub {
-    private static let queue = DispatchQueue(label: "io.ionic.portals.pubsub")
+// An interface that enables marshalling data to and from a ``Portal`` over an event bus
+public class PortalsPubSub {
+    private var publishers = ConcurrentDictionary<String, PassthroughSubject<SubscriptionResult, Never>>(label: "io.ionic.portals.subjects")
     
-    private static var subscriptions: [String: [Int: (SubscriptionResult) -> Void]] = [:]
-    private static var subscriptionRef = 0
-    
-    /// Subscribe to a topic and execute the provided callback when the event is received.
-    /// - Parameters:
-    ///   - topic: The topic to listen for events on
-    ///   - callback: The code to be executed when an event is received for the topic
-    /// - Returns: A subscription reference to use for unsubscribing
-    /// > Tip: Using this method requires you to call ``unsubscribe(from:subscriptionRef:)`` when finished.
-    /// Use ``subscribe(to:_:)`` to get an `AnyCancellable` that will automatically unsubscribe from the topic on deallocation.
-    public static func subscribe(_ topic: String, _ callback: @escaping (SubscriptionResult) -> Void) -> Int {
-        queue.sync {
-            subscriptionRef += 1
-            
-            if var subscription = subscriptions[topic] {
-                subscription[subscriptionRef] = callback
-                subscriptions[topic] = subscription
-            } else {
-                let subscription = [subscriptionRef : callback]
-                subscriptions[topic] = subscription
-            }
-            
-            return subscriptionRef
-        }
-    }
-    
+    public init() {}
+
     /// Subscribe to a topic and execute the provided callback when the event is received.
     /// - Parameters:
     ///   - topic: The topic to listen for events on
     ///   - callback: The code to be executed when an event is received for the topic
     /// - Returns: An `AnyCancellable` that unsubscribes from the topic when deallocated.
-    public static func subscribe(to topic: String, _ callback: @escaping (SubscriptionResult) -> Void) -> AnyCancellable {
-        let ref = subscribe(topic, callback)
-        return AnyCancellable { unsubscribe(from: topic, subscriptionRef: ref) }
+    public func subscribe(to topic: String, _ callback: @escaping (SubscriptionResult) -> Void) -> AnyCancellable {
+        let publisher = subject(for: topic)
+        let cancellable = publisher.sink(receiveValue: callback)
+        return cancellable
+    }
+    
+    internal func subject(for topic: String) -> PassthroughSubject<SubscriptionResult, Never> {
+        let publisher: PassthroughSubject<SubscriptionResult, Never>
+        if let existing = publishers[topic] {
+            publisher = existing
+        } else {
+            publisher = PassthroughSubject<SubscriptionResult, Never>()
+            publishers[topic] = publisher
+        }
+        
+        return publisher
     }
     
     /// Publish event to all listeners of a topic
     /// - Parameters:
     ///   - message: The data to deliver to all subscribers. Must be a valid JSON data type. Defaults to nil.
     ///   - topic: The topic to publish to
-    public static func publish(_ message: JSValue? = nil, to topic: String) {
-        queue.async {
-            if let subscription = subscriptions[topic] {
-                for (ref, listener) in subscription {
-                    let result = SubscriptionResult(topic: topic, data: message, subscriptionRef: ref)
-                    listener(result)
-                }
-            }
-        }
+    public func publish(_ message: JSValue? = nil, to topic: String) {
+        publishers[topic]?.send(SubscriptionResult(topic: topic, data: message))
     }
     
-    /// Stop receiving events. This must must be called to prevent a closure from being executed indefinitely
+    /// Shared PubSub instance to publish events globally amongst subscribers
+    public static let shared = PortalsPubSub()
+    
+    /// Subscribe to a topic and execute the provided callback when the event is received. Uses ``shared`` to subscribe.
     /// - Parameters:
-    ///   - topic: The topic to unsubscribe from
-    ///   - subscriptionRef: The subscriptionRef provided during subscription
-    public static func unsubscribe(from topic: String, subscriptionRef: Int) {
-        queue.async {
-            if var subscription = subscriptions[topic] {
-                subscription[subscriptionRef] = nil
-                subscriptions[topic] = subscription
+    ///   - topic: The topic to listen for events on
+    ///   - callback: The code to be executed when an event is received for the topic
+    /// - Returns: An `AnyCancellable` that unsubscribes from the topic when deallocated.
+    public static func subscribe(to topic: String, _ callback: @escaping (SubscriptionResult) -> Void) -> AnyCancellable {
+        shared.subscribe(to: topic, callback)
+    }
+    
+    /// Publish event to all listeners of a topic. Uses ``shared`` to publish.
+    /// - Parameters:
+    ///   - message: The data to deliver to all subscribers. Must be a valid JSON data type. Defaults to nil.
+    ///   - topic: The topic to publish to
+    public static func publish(_ message: JSValue? = nil, to topic: String) {
+        shared.publish(message, to: topic)
+    }
+}
+
+class ConcurrentDictionary<Key: Hashable, Value> {
+    private var _dict: Dictionary<Key, Value>
+    var dict: Dictionary<Key, Value> {
+        queue.sync { _dict }
+    }
+    private let queue: DispatchQueue
+    
+    init(label: String, dict: [Key: Value] = [:]) {
+        queue = DispatchQueue(label: label, qos: .userInitiated, attributes: .concurrent)
+        self._dict = dict
+    }
+    
+    subscript(_ key: Key) -> Value? {
+        get { queue.sync { _dict[key] } }
+        set {
+            queue.async(flags: .barrier) { [weak self] in
+                self?._dict[key] = newValue
             }
         }
     }
+}
+
+extension ConcurrentDictionary: Collection {
+    var startIndex: Dictionary<Key, Value>.Index { dict.startIndex }
+    var endIndex: Dictionary<Key, Value>.Index { dict.endIndex }
+    func index(after i: Dictionary<Key, Value>.Index) -> Dictionary<Key, Value>.Index {
+        dict.index(after: i)
+    }
     
+    subscript(position: Dictionary<Key, Value>.Index) -> Dictionary<Key, Value>.Element {
+        get {
+            dict[position]
+        }
+    }
 }
 
 /// The data emitted to a subscriber
@@ -85,20 +109,25 @@ public struct SubscriptionResult {
     public var topic: String
     /// The value emitted
     public var data: JSValue?
-    /// The reference to the subscription. Used for calling ``PortalsPubSub/unsubscribe(from:subscriptionRef:)``
-    public var subscriptionRef: Int
     
     var dictionaryRepresentation: [String: JSValue?] {
         return [
             "topic": topic,
-            "data": data,
-            "subscriptionRef": subscriptionRef
+            "data": data
         ]
     }
 }
 
 /// An Objective-C interface that enables marshalling data to and from a ``Portal`` over an event bus. If using Swift, ``PortalsPubSub`` is the perferred interface.
 @objc public class IONPortalsPubSub: NSObject {
+    class Cancellable: NSObject {
+        var cancellable: AnyCancellable
+        init(_ cancellable: AnyCancellable) {
+            self.cancellable = cancellable
+        }
+    }
+    
+    
     private override init() { }
     
     /// Subscribe to a topic and execute the provided callback when the event is received.
@@ -106,11 +135,13 @@ public struct SubscriptionResult {
     ///   - topic: The topic to listen for events on
     ///   - callback: The code to be executed when an event is received for the topic
     /// - Returns: A subscription reference to use for unsubscribing
-    /// > Tip: Using this method requires you to call ``unsubscribe(from:subscriptionRef:)`` when finished.
-    @objc(subscribeToTopic:callback:) public static func subscribe(topic: String, callback: @escaping ([String: Any]) -> Void) -> Int {
-        PortalsPubSub.subscribe(topic) { result in
+    /// > Tip: You must retain a reference to the returned to keep the subscription alive. To unsubscribe, set the the reference to nil.
+    @objc(subscribeToTopic:callback:) public static func subscribe(topic: String, callback: @escaping ([String: Any]) -> Void) -> Any {
+        let cancellable = PortalsPubSub.subscribe(to: topic) { result in
             callback(result.dictionaryRepresentation as [String: Any])
         }
+        
+        return Cancellable(cancellable)
     }
         
     /// Publish event to all listeners of a topic
@@ -121,14 +152,6 @@ public struct SubscriptionResult {
         guard let data = message else { return PortalsPubSub.publish(to: topic) }
         guard let value = coerceToJsValue(data) else { return print("\(data) is not a valid JSON type...not publishing") }
         PortalsPubSub.publish(value, to: topic)
-    }
-    
-    /// Stop receiving events. This must be called if subscribing occured through ``subscribe(topic:callback:)`` to prevent a closure from being executed indefinitely.
-    /// - Parameters:
-    ///   - topic: The topic to unsubscribe from
-    ///   - subscriptionRef: The subscriptionRef provided during subscription
-    @objc(unsubscribeFromTopic:subscriptionRef:) public static func unsubscribe(from topic: String, subscriptionRef: Int) {
-        PortalsPubSub.unsubscribe(from: topic, subscriptionRef: subscriptionRef)
     }
     
     // This is needed because NSDictionary, NSArray, NSString, NSDate do not coerce to their bridged types when their bridged types conform to JSValue, so we need to do so here.

--- a/Tests/IonicPortalsObjcTests/IonicPortalsObjcTests.m
+++ b/Tests/IonicPortalsObjcTests/IonicPortalsObjcTests.m
@@ -17,7 +17,7 @@
 - (void)testIONPubSub__when_provided_a_simple_json_compatible_value__it_can_be_coerced_correctly {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Callback should have fired"];
     
-    NSInteger subRef = [IONPortalsPubSub subscribeToTopic:@"test" callback:^(NSDictionary<NSString *,id> * _Nonnull dict) {
+    id subRef = [IONPortalsPubSub subscribeToTopic:@"test" callback:^(NSDictionary<NSString *,id> * _Nonnull dict) {
         BOOL aBool = dict[@"data"];
         XCTAssertTrue(aBool);
         [expectation fulfill];
@@ -26,14 +26,13 @@
     [IONPortalsPubSub publishMessage:@YES toTopic:@"test"];
     
     [self waitForExpectations:@[expectation] timeout:1.0];
-    [IONPortalsPubSub unsubscribeFromTopic:@"test" subscriptionRef:subRef];
 }
 
 - (void)testIONPubSub__when_provided_a_non_json_compatible_value__it_cannot_be_coerced_correctly {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Callback should not have fired"];
     [expectation setInverted:YES];
     
-    NSInteger subRef = [IONPortalsPubSub subscribeToTopic:@"test" callback:^(NSDictionary<NSString *,id> * _Nonnull dict) {
+    id subRef = [IONPortalsPubSub subscribeToTopic:@"test" callback:^(NSDictionary<NSString *,id> * _Nonnull dict) {
         [expectation fulfill];
     }];
     
@@ -41,7 +40,6 @@
     [IONPortalsPubSub publishMessage:nonJsonCompatible toTopic:@"test"];
     
     [self waitForExpectations:@[expectation] timeout:1.0];
-    [IONPortalsPubSub unsubscribeFromTopic:@"test" subscriptionRef:subRef];
 }
 
 - (void)testIONPubSub__when_provided_a_json_compatible_nsdictionary__it_correctly_coerces_it {
@@ -58,7 +56,7 @@
         }
     };
     
-    NSInteger subRef = [IONPortalsPubSub subscribeToTopic:@"test" callback:^(NSDictionary<NSString *,id> * _Nonnull dict) {
+    id subRef = [IONPortalsPubSub subscribeToTopic:@"test" callback:^(NSDictionary<NSString *,id> * _Nonnull dict) {
         NSDictionary *publishedDict = dict[@"data"];
         XCTAssertTrue([publishedDict isEqualToDictionary:aDict]);
         [expectation fulfill];
@@ -67,7 +65,6 @@
     [IONPortalsPubSub publishMessage:aDict toTopic:@"test"];
     
     [self waitForExpectations:@[expectation] timeout:1.0];
-    [IONPortalsPubSub unsubscribeFromTopic:@"test" subscriptionRef:subRef];
 }
 
 - (void)testIONPubSub__when_provided_an_nsdictionary_with_objects_incompatible_with_json__it_only_coerces_valid_data {
@@ -85,7 +82,7 @@
         }
     };
     
-    NSInteger subRef = [IONPortalsPubSub subscribeToTopic:@"test" callback:^(NSDictionary<NSString *,id> * _Nonnull dict) {
+    id subRef = [IONPortalsPubSub subscribeToTopic:@"test" callback:^(NSDictionary<NSString *,id> * _Nonnull dict) {
         NSDictionary *publishedDict = dict[@"data"];
         NSDictionary *expectedDict = @{
             @"number": @1,
@@ -105,7 +102,6 @@
     [IONPortalsPubSub publishMessage:aDictToPublish toTopic:@"test"];
     
     [self waitForExpectations:@[expectation] timeout:1.0];
-    [IONPortalsPubSub unsubscribeFromTopic:@"test" subscriptionRef:subRef];
 }
 
 - (void)testIONPubSub__when_provided_a_json_compatible_nsarray__it_correctly_coerces_it {
@@ -113,7 +109,7 @@
     
     NSArray *anArray = @[@"hello", @43, @45.5, [NSNull null]];
     
-    NSInteger subRef = [IONPortalsPubSub subscribeToTopic:@"test" callback:^(NSDictionary<NSString *,id> * _Nonnull dict) {
+    id subRef = [IONPortalsPubSub subscribeToTopic:@"test" callback:^(NSDictionary<NSString *,id> * _Nonnull dict) {
         NSArray *publishedArray = dict[@"data"];
         XCTAssertTrue([publishedArray isEqualToArray:anArray]);
         [expectation fulfill];
@@ -122,7 +118,6 @@
     [IONPortalsPubSub publishMessage:anArray toTopic:@"test"];
     
     [self waitForExpectations:@[expectation] timeout:1.0];
-    [IONPortalsPubSub unsubscribeFromTopic:@"test" subscriptionRef:subRef];
 }
 
 - (void)testIONPubSub__when_provided_an_nsarray_with_incompatible_elements__incompatible_elements_are_ignored {
@@ -130,7 +125,7 @@
     
     NSArray *anArray = @[@"hello", [[NSError alloc] initWithDomain:NSCocoaErrorDomain code:1 userInfo:nil], @43, @45.5, [NSNull null], [[NSPredicate alloc] init]];
     
-    NSInteger subRef = [IONPortalsPubSub subscribeToTopic:@"test" callback:^(NSDictionary<NSString *,id> * _Nonnull dict) {
+    id subRef = [IONPortalsPubSub subscribeToTopic:@"test" callback:^(NSDictionary<NSString *,id> * _Nonnull dict) {
         NSArray *publishedArray = dict[@"data"];
         NSArray *expectedArray = @[@"hello", @43, @45.5, [NSNull null]];
         XCTAssertTrue([publishedArray isEqualToArray:expectedArray]);
@@ -140,7 +135,6 @@
     [IONPortalsPubSub publishMessage:anArray toTopic:@"test"];
     
     [self waitForExpectations:@[expectation] timeout:1.0];
-    [IONPortalsPubSub unsubscribeFromTopic:@"test" subscriptionRef:subRef];
 }
 
 - (void)testIONPortal_init__when_provided_a_valid_json_representable_nsdictionary__it_is_correctly_coerced {


### PR DESCRIPTION
This PR overhauls the pub/sub system on iOS to be drastically simpler. The problem that I originally aimed to solve was Plugin subscriptions not being properly disposed when a Portal is dismissed from the view hierarchy. In the process I addressed a few things as I came up with what I think is a cleaner solution:

1. Using Capacitor for publishing events to a Portal instead of reinventing our own system. This also makes unsubscribing much simpler since the user is returned a handle that they can call `remove` on and stop receiving events without having to hold on to an arbitrary integer we created for housekeeping purposes. That handle still needs to be held onto if they do want to stop events, but it's not a big deal if they don't, they'll just continue to receive those events if they need to until the portal is removed from the view.
2. Rebuilding the pub/sub system to use Combine so that housekeeping of subscriptions would be managed in a familiar way on iOS and we don't have to worry about iterating over a collection of closures with captured plugin calls. We could have also continued the previous approach and weakly capturing the plugin call as well. However, I'd rather just not do that at all.
3. I made PortalsPubSub a class (along with a `shared` singleton) that could be used to create an instance of `PortalsPlugin` that can scope events to specific portals instead of everything being global.
