### PR TITLE
feat!: BREAKING Required Manual Plugin Registration

### DIFF
--- a/Sources/IonicPortals/IonicPortals.docc/IonicPortals.md
+++ b/Sources/IonicPortals/IonicPortals.docc/IonicPortals.md
@@ -24,6 +24,7 @@ IonicPortals provides tools to configure, render, and communicate with embedded 
 ### Communicating Between Web and Native
 
 - ``PortalsPubSub``
+- ``PortalsPlugin``
 - ``SubscriptionResult``
 
 ### Assets

--- a/Sources/IonicPortals/IonicPortals.docc/Portal.md
+++ b/Sources/IonicPortals/IonicPortals.docc/Portal.md
@@ -4,7 +4,7 @@
 
 ### Create a Portal
 
-- ``init(name:startDir:index:bundle:initialContext:assetMaps:pluginRegistrationMode:liveUpdateManager:liveUpdateConfig:performanceReporter:)``
+- ``init(name:startDir:index:bundle:initialContext:assetMaps:plugins:liveUpdateManager:liveUpdateConfig:performanceReporter:)``
 - ``init(stringLiteral:)``
 
 ### Web App Location 
@@ -15,14 +15,12 @@
 
 ### Plugin Management
 
-- ``pluginRegistrationMode-swift.property``
 - ``adding(_:)-72o29``
 - ``adding(_:)-9sqqz``
 - ``adding(_:)-868wl``
 - ``adding(_:)-9lavd``
 - ``adding(_:)-3kt0j``
 - ``adding(_:)-9utyy``
-- ``PluginRegistrationMode-swift.enum``
 - ``Plugin``
 
 ### Live Updates

--- a/Sources/IonicPortals/Portal.swift
+++ b/Sources/IonicPortals/Portal.swift
@@ -21,8 +21,8 @@ public struct Portal {
     /// Any initial state required by the web application
     public var initialContext: JSObject
     
-    /// Dictates how Capacitor loads plugins when the ``Portal`` loads.
-    public var pluginRegistrationMode: PluginRegistrationMode
+    /// Any Capacitor plugins to load on the ``Portal``
+    public var plugins: [Plugin]
     
     /// The `LiveUpdateManager` responsible for locating the latest source for the web application
     public var liveUpdateManager: LiveUpdateManager
@@ -48,7 +48,7 @@ public struct Portal {
     ///     If `nil`, the portal name is used as the starting directory. Defaults to `nil`.
     ///   - index: The initial file to load in the Portal. Defaults to `index.html`.
     ///   - bundle: The `Bundle` that contains the web application. Defaults to `Bundle.main`.
-    ///   - pluginRegistrationMode: Dictates how Capacitor loads plugins. Defaults to ``PluginRegistrationMode-swift.enum/automatic``.
+    ///   - plugins: Any ``Plugin``s to load. Defautls to `[]`.
     ///   - initialContext: Any initial state required by the web application. Defaults to `[:]`.
     ///   - assetMaps: Any ``AssetMap``s needed to share assets with the ``Portal``. Defaults to `[]`.
     ///   - liveUpdateManager: The `LiveUpdateManager` responsible for locating the source source for the web application. Defaults to `LiveUpdateManager.shared`.
@@ -61,7 +61,7 @@ public struct Portal {
         bundle: Bundle = .main,
         initialContext: JSObject = [:],
         assetMaps: [AssetMap] = [],
-        pluginRegistrationMode: PluginRegistrationMode = .automatic,
+        plugins: [Plugin] = [],
         liveUpdateManager: LiveUpdateManager = .shared,
         liveUpdateConfig: LiveUpdate? = nil,
         performanceReporter: WebPerformanceReporter? = nil
@@ -71,7 +71,7 @@ public struct Portal {
         self.index = index
         self.initialContext = initialContext
         self.bundle = bundle
-        self.pluginRegistrationMode = pluginRegistrationMode
+        self.plugins = plugins
         self.liveUpdateManager = liveUpdateManager
         self.liveUpdateConfig = liveUpdateConfig
         self.performanceReporter = performanceReporter
@@ -84,78 +84,46 @@ public struct Portal {
 
 extension Portal {
     
-    /// Returns a new ``Portal`` with the plugins added to the registration mode.
-    /// > Important: This sets ``Portal/pluginRegistrationMode-swift.property`` to ``PluginRegistrationMode-swift.enum/manual(_:)``.
-    /// If the ``Portal/pluginRegistrationMode-swift.property`` is already ``PluginRegistrationMode-swift.enum/manual(_:)``, the plugins
-    /// passed to this method are appended to the existing plugins. Any duplicated plugins will be overridden, with the last plugin taking
-    /// precedence.
+    /// Returns a new ``Portal`` with the plugins added to ``plugins``.
     /// - Parameter plugins: The plugins to manually register
-    /// - Returns: A new ``Portal`` with the plugins added to ``Portal/pluginRegistrationMode-swift.property``
+    /// - Returns: A new ``Portal`` with the plugins added to ``plugins``
     public func adding(_ plugins: [Plugin]) -> Portal {
         var copy = self
-
-        switch copy.pluginRegistrationMode {
-        case .automatic:
-            copy.pluginRegistrationMode = .manual(plugins)
-        case .manual(var existingPlugins):
-            existingPlugins.append(contentsOf: plugins)
-            copy.pluginRegistrationMode = .manual(existingPlugins)
-        }
-
+        copy.plugins.append(contentsOf: plugins)
         return copy
     }
     
-    /// Returns a new ``Portal`` with the plugin added to the registration mode.
-    /// > Important: This sets ``Portal/pluginRegistrationMode-swift.property`` to ``PluginRegistrationMode-swift.enum/manual(_:)``.
-    /// If the ``Portal/pluginRegistrationMode-swift.property`` is already ``PluginRegistrationMode-swift.enum/manual(_:)``, the plugin
-    /// passed to this method is appended to the existing plugins. Any duplicated plugins will be overridden, with the last plugin taking
-    /// precedence.
+    /// Returns a new ``Portal`` with the plugin added to ``plugins``.
     /// - Parameter plugin: The plugin to manually register
-    /// - Returns: A new ``Portal`` with the plugin added to ``Portal/pluginRegistrationMode-swift.property``
+    /// - Returns: A new ``Portal`` with the plugin added to ``plugins``
     public func adding(_ plugin: Plugin) -> Portal {
         adding([plugin])
     }
     
-    /// Returns a new ``Portal`` with the plugin instance added to the registration mode.
-    /// > Important: This sets ``Portal/pluginRegistrationMode-swift.property`` to ``PluginRegistrationMode-swift.enum/manual(_:)``.
-    /// If the ``Portal/pluginRegistrationMode-swift.property`` is already ``PluginRegistrationMode-swift.enum/manual(_:)``, the plugin
-    /// passed to this method is appended to the existing plugins. Any duplicated plugins will be overridden, with the last plugin taking
-    /// precedence.
+    /// Returns a new ``Portal`` with the plugin instance added to ``plugins``.
     /// - Parameter plugin: The plugin instance to manually register
-    /// - Returns: A new ``Portal`` with the plugin instance added to ``Portal/pluginRegistrationMode-swift.property``
+    /// - Returns: A new ``Portal`` with the plugin instance added to ``plugins``
     public func adding(_ plugin: CAPPlugin) -> Portal {
         adding([.instance(plugin)])
     }
     
-    /// Returns a new ``Portal`` with the plugin type added to the registration mode.
-    /// > Important: This sets ``Portal/pluginRegistrationMode-swift.property`` to ``PluginRegistrationMode-swift.enum/manual(_:)``.
-    /// If the ``Portal/pluginRegistrationMode-swift.property`` is already ``PluginRegistrationMode-swift.enum/manual(_:)``, the plugin
-    /// passed to this method is appended to the existing plugins. Any duplicated plugins will be overridden, with the last plugin taking
-    /// precedence.
+    /// Returns a new ``Portal`` with the plugin type added to ``plugins``.
     /// - Parameter pluginType: The plugin type to manually register
-    /// - Returns: A new ``Portal`` with the plugin type added to ``Portal/pluginRegistrationMode-swift.property``
+    /// - Returns: A new ``Portal`` with the plugin type added to ``plugins``
     public func adding(_ pluginType: CAPPlugin.Type) -> Portal {
         adding([.type(pluginType)])
     }
     
-    /// Returns a new ``Portal`` with the plugin instances added to the registration mode.
-    /// > Important: This sets ``Portal/pluginRegistrationMode-swift.property`` to ``PluginRegistrationMode-swift.enum/manual(_:)``.
-    /// If the ``Portal/pluginRegistrationMode-swift.property`` is already ``PluginRegistrationMode-swift.enum/manual(_:)``, the plugins
-    /// passed to this method are appended to the existing plugins. Any duplicated plugins will be overridden, with the last plugin taking
-    /// precedence.
+    /// Returns a new ``Portal`` with the plugin instances added to ``plugins``.
     /// - Parameter plugins: The plugin instances to manually register
-    /// - Returns: A new ``Portal`` with the plugin instances added to ``Portal/pluginRegistrationMode-swift.property``
+    /// - Returns: A new ``Portal`` with the plugin instances added to ``plugins``
     public func adding(_ plugins: [CAPPlugin]) -> Portal {
         adding(plugins.map(Plugin.instance))
     }
     
-    /// Returns a new ``Portal`` with the plugin types added to the registration mode.
-    /// > Important: This sets ``Portal/pluginRegistrationMode-swift.property`` to ``PluginRegistrationMode-swift.enum/manual(_:)``.
-    /// If the ``Portal/pluginRegistrationMode-swift.property`` is already ``PluginRegistrationMode-swift.enum/manual(_:)``, the plugins
-    /// passed to this method are appended to the existing plugins. Any duplicated plugins will be overridden, with the last plugin taking
-    /// precedence.
+    /// Returns a new ``Portal`` with the plugin types added to ``plugins``.
     /// - Parameter pluginTypes: The plugins types to manually register
-    /// - Returns: A new ``Portal`` with the plugin instances added to ``Portal/pluginRegistrationMode-swift.property``
+    /// - Returns: A new ``Portal`` with the plugin instances added to ``plugins``
     public func adding(_ pluginTypes: [CAPPlugin.Type]) -> Portal {
         adding(pluginTypes.map(Plugin.type))
     }
@@ -173,33 +141,22 @@ extension Portal: ExpressibleByStringLiteral {
 }
 
 extension Portal {
-    
-    /// The method of registering plugins with the Capacitor runtime when a ``Portal`` loads.
-    public enum PluginRegistrationMode {
-        /// Automatically registers all eligible plugins.
-        case automatic
-        /// Only registers the plugins provided
-        case manual([Plugin])
-    }
-    
+    /// The two ways of registering Capacitor Plugins with a Portal.
     ///
+    /// A ``type(_:)`` is initialized by the bridge on the users behalf.
+    /// An ``instance(_:)`` is given directly to the bridge.
     public enum Plugin {
         /// Allow the Capacitor runtime to initialize the plugin on your behalf.
-        /// Plugins registered in this manner are effectively singletons.
+        /// > Note: If you are using plugin from the official or community plugins
+        /// this is usually the best option
         case type(CAPPlugin.Type)
         /// Registers the instance with the Capacitor runtime.
+        /// > Note: This is usually a good option if you have custom plugins
+        /// you have written for your application that need to be passed
+        /// via initialization or otherwise having the instance beforehand is needed
+        /// before providing it to the capacitor bridge. The ``PortalsPlugin`` ``PortalsPlugin/init(pubsub:)``
+        /// initializer is an example of a scenario where you would need to use ``instance(_:)``.
         case instance(CAPPlugin)
-    }
-}
-
-extension Portal.PluginRegistrationMode {
-    var isAutomatic: Bool {
-        switch self {
-        case .automatic:
-            return true
-        default:
-            return false
-        }
     }
 }
 

--- a/Sources/IonicPortals/PortalUIView.swift
+++ b/Sources/IonicPortals/PortalUIView.swift
@@ -76,20 +76,18 @@ public class PortalUIView: UIView {
         init(portal: Portal, liveUpdatePath: URL?) {
             self.portal = portal
             self.liveUpdatePath = liveUpdatePath
-            super.init(autoRegisterPlugins: portal.pluginRegistrationMode.isAutomatic)
+            super.init(autoRegisterPlugins: false)
         }
         
         override func capacitorDidLoad() {
-            if case let .manual(plugins) = portal.pluginRegistrationMode {
-                bridge.registerPluginType(PortalsPlugin.self)
+            bridge.registerPluginInstance(PortalsPlugin())
 
-                plugins.forEach { plugin in
-                    switch plugin {
-                    case .instance(let instance):
-                        bridge.registerPluginInstance(instance)
-                    case .type(let pluginType):
-                        bridge.registerPluginType(pluginType)
-                    }
+            portal.plugins.forEach { plugin in
+                switch plugin {
+                case .instance(let instance):
+                    bridge.registerPluginInstance(instance)
+                case .type(let pluginType):
+                    bridge.registerPluginType(pluginType)
                 }
             }
         }

--- a/Sources/IonicPortals/PortalsPlugin.swift
+++ b/Sources/IonicPortals/PortalsPlugin.swift
@@ -3,19 +3,19 @@ import Capacitor
 import Combine
 
 @objc(IONPortalsPlugin)
-public final class PortalsPlugin: CAPPlugin, CAPBridgedPlugin {
+public final class PortalsPlugin: CAPInstancePlugin, CAPBridgedPlugin {
     public let identifier = "IONPortalsPlugin"
     public let jsName = "Portals"
     public let pluginMethods: [CAPPluginMethod] = [
         CAPPluginMethod(name: "publishNative", returnType: CAPPluginReturnPromise)
     ]
     
-    private var publishers = ConcurrentDictionary(label: "io.ionic.portalsplugin", dict: [String: AnyCancellable]())
-    private var pubsub: PortalsPubSub = .shared
+    private let publishers = ConcurrentDictionary(label: "io.ionic.portalsplugin", dict: [String: AnyCancellable]())
+    private let pubsub: PortalsPubSub
     
-    public convenience init(pubsub: PortalsPubSub) {
-        self.init()
+    public init(pubsub: PortalsPubSub = .shared) {
         self.pubsub = pubsub
+        super.init()
     }
     
     @objc func publishNative(_ call: CAPPluginCall) {


### PR DESCRIPTION
Removes `PluginRegistrationStrategy` and forces all plugins to be explicitly registered with the Portal. This makes the API more in line with how Android behaves and also avoids crashes that sometimes occur in larger applications using Portals that inadvertently use automatic registration without knowing it.