### PR TITLE
feat: Add ability to configure capacitor programmatically through `Portal`

### DIFF
--- a/Sources/IonicPortals/IonicPortals.docc/IonicPortals.md
+++ b/Sources/IonicPortals/IonicPortals.docc/IonicPortals.md
@@ -33,7 +33,7 @@ IonicPortals provides tools to configure, render, and communicate with embedded 
 
 ### Web Performance
 
-- ``WebPerformanceReporter``
+- ``WebVitalsPlugin``
 
 ### Objective-C Compatibility
 

--- a/Sources/IonicPortals/IonicPortals.docc/Portal.md
+++ b/Sources/IonicPortals/IonicPortals.docc/Portal.md
@@ -4,7 +4,7 @@
 
 ### Create a Portal
 
-- ``init(name:startDir:index:bundle:initialContext:assetMaps:plugins:liveUpdateManager:liveUpdateConfig:performanceReporter:)``
+- ``init(name:startDir:index:bundle:initialContext:assetMaps:plugins:liveUpdateManager:liveUpdateConfig:)``
 - ``init(stringLiteral:)``
 
 ### Web App Location 
@@ -31,6 +31,10 @@
 ### Initial Application State
 
 - ``initialContext``
+
+### Configuring Capacitor
+
+- ``configuring(_:_:)``
 
 ### Name
 

--- a/Sources/IonicPortals/PortalUIView.swift
+++ b/Sources/IonicPortals/PortalUIView.swift
@@ -95,15 +95,21 @@ public class PortalUIView: UIView {
         required init?(coder: NSCoder) {
             fatalError("init(coder:) has not been implemented")
         }
-        
+
         override func instanceDescriptor() -> InstanceDescriptor {
+            let descriptor = createInstanceDescriptor()
+            portal.descriptorConfiguration.forEach { $0(descriptor) }
+            return descriptor
+        }
+
+        private func createInstanceDescriptor() -> InstanceDescriptor {
             let bundleURL = portal.bundle.url(forResource: portal.startDir, withExtension: nil)
             
             guard let path = liveUpdatePath ?? bundleURL else {
                 // DCG this should throw or something else
                 return InstanceDescriptor()
             }
-            
+
             var capConfigUrl = portal.bundle.url(forResource: "capacitor.config", withExtension: "json", subdirectory: portal.startDir)
             var cordovaConfigUrl = portal.bundle.url(forResource: "config", withExtension: "xml", subdirectory: portal.startDir)
 
@@ -121,7 +127,8 @@ public class PortalUIView: UIView {
             descriptor.handleApplicationNotifications = false
             return descriptor
         }
-        
+
+
         override func loadInitialContext(_ userContentViewController: WKUserContentController) {
             let portalInitialContext: String
 


### PR DESCRIPTION
This allows for configuring capacitor programmatically:
```swift
VStack {
  PortalView(
    portal: Portal(name: "foo")
      .configuring(\.isWebDebuggable, true)
      .configuring(\.backgroundColor, .white) 
  )
}
```

I'm not 100% married to the name of this function, but I really couldn't think of anything better.